### PR TITLE
[feat] Add configuration option for portal activation and deactivation sound volume

### DIFF
--- a/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
@@ -39,6 +39,7 @@ import org.bukkit.scheduler.BukkitTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.oddlama.vane.annotation.VaneModule;
+import org.oddlama.vane.annotation.config.ConfigDouble;
 import org.oddlama.vane.annotation.config.ConfigExtendedMaterial;
 import org.oddlama.vane.annotation.config.ConfigLong;
 import org.oddlama.vane.annotation.config.ConfigMaterialMapEntry;
@@ -165,6 +166,22 @@ public class Portals extends Module<Portals> {
 		desc = "The default portal icon. Also accepts heads from the head library."
 	)
 	public ExtendedMaterial config_default_icon;
+
+	@ConfigDouble(
+		def = 0.9,
+		min = 0.0,
+		max = 2.0,
+		desc = "Volume for the portal activation sound effect. 0 to disable."
+	)
+	public double config_volume_activation;
+
+	@ConfigDouble(
+		def = 1.2,
+		min = 0.0,
+		max = 2.0,
+		desc = "Volume for the portal deactivation sound effect. 0 to disable."
+	)
+	public double config_volume_deactivation;
 
 	@LangMessage
 	public TranslatedMessage lang_console_display_active;

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
@@ -170,15 +170,15 @@ public class Portals extends Module<Portals> {
 	@ConfigDouble(
 		def = 0.9,
 		min = 0.0,
-		max = 2.0,
+		max = 1.0,
 		desc = "Volume for the portal activation sound effect. 0 to disable."
 	)
 	public double config_volume_activation;
 
 	@ConfigDouble(
-		def = 1.2,
+		def = 1.0,
 		min = 0.0,
-		max = 2.0,
+		max = 1.0,
 		desc = "Volume for the portal deactivation sound effect. 0 to disable."
 	)
 	public double config_volume_deactivation;

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/portal/Portal.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/portal/Portal.java
@@ -321,8 +321,13 @@ public class Portal {
 		// Activate all controlling levers
 		set_controlling_levers(true);
 
-		// Play sound
-		spawn().getWorld().playSound(spawn(), Sound.BLOCK_END_PORTAL_SPAWN, SoundCategory.BLOCKS, 0.9f, 0.8f);
+		float sound_volume = (float) portals.config_volume_activation;
+		if (sound_volume > 0.0f) {
+			// Play sound
+			spawn()
+				.getWorld()
+				.playSound(spawn(), Sound.BLOCK_END_PORTAL_SPAWN, SoundCategory.BLOCKS, sound_volume, 0.8f);
+		}
 	}
 
 	public void on_disconnect(final Portals portals, final Portal target) {
@@ -332,8 +337,13 @@ public class Portal {
 		// Deactivate all controlling levers
 		set_controlling_levers(false);
 
-		// Play sound
-		spawn().getWorld().playSound(spawn(), Sound.BLOCK_END_PORTAL_FRAME_FILL, SoundCategory.BLOCKS, 1.2f, 0.5f);
+		float sound_volume = (float) portals.config_volume_deactivation;
+		if (sound_volume > 0.0f) {
+			// Play sound
+			spawn()
+				.getWorld()
+				.playSound(spawn(), Sound.BLOCK_END_PORTAL_FRAME_FILL, SoundCategory.BLOCKS, sound_volume, 0.5f);
+		}
 	}
 
 	public void update_blocks(final Portals portals) {


### PR DESCRIPTION
the sound was giving everyone on my server a heart attack

(in my config when testing locally, I liked 0.35 for activation and leaving deactivation unchanged from default)