### PR TITLE
Adds required changes to build on Windows & JDK 17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ env.sh
 .project
 .settings
 .idea
-gradle.properties
 build
 libs/
 target/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ subprojects {
 
 	tasks.withType<JavaCompile> {
 		options.compilerArgs.addAll(arrayOf("-Xlint:all", "-Xlint:-processing", "-Xdiags:verbose"))
+		options.encoding = "UTF-8"
 	}
 
 	dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED

--- a/vane-core/build.gradle.kts
+++ b/vane-core/build.gradle.kts
@@ -1,4 +1,4 @@
-import java.io.ByteArrayOutputStream
+import java.security.MessageDigest;
 
 plugins {
 	id("com.github.johnrengelman.shadow") version "7.1.0"
@@ -11,12 +11,14 @@ dependencies {
 	implementation(project(":vane-annotations"))
 }
 
-val resource_pack_sha1: String = ByteArrayOutputStream().use { outputStream ->
-	project.exec {
-		commandLine("sha1sum", "../docs/resourcepacks/v" + project.version + ".zip")
-		standardOutput = outputStream
-	}
-	outputStream.toString().split(" ")[0]
+val resource_pack_sha1 by lazy {
+	val resourcePack = File("${projectDir}/../docs/resourcepacks/v" + project.version + ".zip")
+	val md = MessageDigest.getInstance("SHA-1")
+	val resourcePackBytes = resourcePack.readBytes()
+	md.update(resourcePackBytes, 0, resourcePackBytes.size)
+	val sha1bytes = md.digest()
+	val sha1hashString = String.format("%040x", BigInteger(1, sha1bytes))
+	sha1hashString
 }
 
 tasks {


### PR DESCRIPTION
As discussed in discord, I was having troubles building vane on windows.

There were 3 changes required grouped into 2 root causes:

1. Running with JVM flags to enable unsafe access to specific sun internal classes for https://github.com/diffplug/spotless/issues/834 which doesn't have a better workaround as of yet.

I'm unhappy with committing gradle.properties considering it was inside the gitignore, but this seems like the best way for now to ensure new developers don't run into the same issue.

2. Forcing the encoding to use UTF-8. I could have used gradle.properties for this again, but including it in the build script seems the best way to force new developers to use the correct encoding. This could get complicated if git attempts to convert between encodings, but that is fairly unlikely given standard practice for windows / linux cross development.

3. Making the sha1 calculation cross-platform, the easiest solution was to use the default java libraries in java.security.

I tested that the sha1 hash outputs `1bbc0027ae970ce71fd5fed1f14294b8fd77e5d8` which you confirmed matches the release hash.

Let me know if you need further changes, but I hate rebasing too much on git, so I hope you are happy :-).