### PR TITLE
Dev Feature: Live Reloading Resource Packs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,5 +121,43 @@ configure(subprojects.filter {
 
 runPaper {
 	disablePluginJarDetection()
+}
 
+tasks.create<Delete>("cleanVaneRuntimeTranslations") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/lang-*.yml")
+	})
+}
+
+tasks.create<Delete>("cleanVaneConfigurations") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/config.yml")
+	})
+}
+
+tasks.create<Delete>("cleanVaneStorage") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/storage.json")
+	})
+}
+
+tasks.create<Delete>("cleanVane") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/")
+	})
+}
+
+tasks.create<Delete>("cleanWorld") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include(
+				"world",
+				"world_nether",
+				"world_the_end"
+		)
+	})
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/Core.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/Core.java
@@ -100,6 +100,8 @@ public class Core extends Module<Core> implements PluginMessageListener {
 	// Module registry
 	private SortedSet<Module<?>> vane_modules = new TreeSet<>((a, b) -> a.get_name().compareTo(b.get_name()));
 
+	public final ResourcePackDistributor resource_pack_distributor;
+
 	public void register_module(Module<?> module) {
 		vane_modules.add(module);
 	}
@@ -164,7 +166,7 @@ public class Core extends Module<Core> implements PluginMessageListener {
 		new org.oddlama.vane.core.commands.Vane(this);
 		new org.oddlama.vane.core.commands.CustomItem(this);
 		menu_manager = new MenuManager(this);
-		new ResourcePackDistributor(this);
+		resource_pack_distributor = new ResourcePackDistributor(this);
 		new CommandHider(this);
 	}
 
@@ -217,8 +219,9 @@ public class Core extends Module<Core> implements PluginMessageListener {
 		getServer().getMessenger().unregisterIncomingPluginChannel(this, CHANNEL_AUTH_MULTIPLEX, this);
 	}
 
-	public boolean generate_resource_pack() {
+	public File generate_resource_pack() {
 		try {
+			var file = new File("vane-resource-pack.zip");
 			var pack = new ResourcePackGenerator();
 			pack.set_description("Vane plugin resource pack");
 			pack.set_icon_png(getResource("pack.png"));
@@ -227,12 +230,12 @@ public class Core extends Module<Core> implements PluginMessageListener {
 				m.generate_resource_pack(pack);
 			}
 
-			pack.write(new File("vane-resource-pack.zip"));
+			pack.write(file);
+			return file;
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "Error while generating resourcepack", e);
-			return false;
+			return null;
 		}
-		return true;
 	}
 
 	public void for_all_module_components(final Consumer1<ModuleComponent<?>> f) {

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
@@ -1,0 +1,67 @@
+package org.oddlama.vane.core;
+
+import com.google.common.hash.Hashing;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class ResourcePackDevServer implements HttpHandler {
+
+    private final ResourcePackDistributor resource_pack_distributor;
+    private final File file;
+
+    public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
+        this.resource_pack_distributor = resource_pack_distributor;
+        this.file = file;
+    }
+
+    public void serve() {
+        try {
+            final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
+            var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
+            resource_pack_distributor.sha1 = hash.toString();
+            resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
+
+            httpServer.createContext("/", this);
+            httpServer.setExecutor(null);
+            httpServer.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void handle(HttpExchange he) throws IOException {
+        String method = he.getRequestMethod();
+        if (!("HEAD".equals(method) || "GET".equals(method))) {
+            he.sendResponseHeaders(501, -1);
+            return;
+        }
+
+        FileInputStream fis;
+        try {
+            fis = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            he.sendResponseHeaders(404, -1);
+            return;
+        }
+
+        he.getResponseHeaders().set("Content-Type", "application/zip");
+        if ("GET".equals(method)) {
+            he.sendResponseHeaders(200, file.length());
+            OutputStream os = he.getResponseBody();
+            fis.transferTo(os);
+            os.close();
+        } else {
+            assert ("HEAD".equals(method));
+            he.sendResponseHeaders(200, -1);
+        }
+        fis.close();
+    }
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
@@ -4,7 +4,6 @@ import com.google.common.hash.Hashing;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -14,54 +13,54 @@ import java.net.InetSocketAddress;
 
 public class ResourcePackDevServer implements HttpHandler {
 
-    private final ResourcePackDistributor resource_pack_distributor;
-    private final File file;
+	private final ResourcePackDistributor resource_pack_distributor;
+	private final File file;
 
-    public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
-        this.resource_pack_distributor = resource_pack_distributor;
-        this.file = file;
-    }
+	public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
+		this.resource_pack_distributor = resource_pack_distributor;
+		this.file = file;
+	}
 
-    public void serve() {
-        try {
-            final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
-            var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
-            resource_pack_distributor.sha1 = hash.toString();
-            resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
+	public void serve() {
+		try {
+			final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
+			var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
+			resource_pack_distributor.sha1 = hash.toString();
+			resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
 
-            httpServer.createContext("/", this);
-            httpServer.setExecutor(null);
-            httpServer.start();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+			httpServer.createContext("/", this);
+			httpServer.setExecutor(null);
+			httpServer.start();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    public void handle(HttpExchange he) throws IOException {
-        String method = he.getRequestMethod();
-        if (!("HEAD".equals(method) || "GET".equals(method))) {
-            he.sendResponseHeaders(501, -1);
-            return;
-        }
+	public void handle(HttpExchange he) throws IOException {
+		String method = he.getRequestMethod();
+		if (!("HEAD".equals(method) || "GET".equals(method))) {
+			he.sendResponseHeaders(501, -1);
+			return;
+		}
 
-        FileInputStream fis;
-        try {
-            fis = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            he.sendResponseHeaders(404, -1);
-            return;
-        }
+		FileInputStream fis;
+		try {
+			fis = new FileInputStream(file);
+		} catch (FileNotFoundException e) {
+			he.sendResponseHeaders(404, -1);
+			return;
+		}
 
-        he.getResponseHeaders().set("Content-Type", "application/zip");
-        if ("GET".equals(method)) {
-            he.sendResponseHeaders(200, file.length());
-            OutputStream os = he.getResponseBody();
-            fis.transferTo(os);
-            os.close();
-        } else {
-            assert ("HEAD".equals(method));
-            he.sendResponseHeaders(200, -1);
-        }
-        fis.close();
-    }
+		he.getResponseHeaders().set("Content-Type", "application/zip");
+		if ("GET".equals(method)) {
+			he.sendResponseHeaders(200, file.length());
+			OutputStream os = he.getResponseBody();
+			fis.transferTo(os);
+			os.close();
+		} else {
+			assert ("HEAD".equals(method));
+			he.sendResponseHeaders(200, -1);
+		}
+		fis.close();
+	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDistributor.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDistributor.java
@@ -2,11 +2,9 @@ package org.oddlama.vane.core;
 
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
-
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -175,5 +173,4 @@ public class ResourcePackDistributor extends Listener<Core> {
 			ResourcePackDistributor.this.sha1 = hash.toString();
 		} catch (IOException ignored) {}
 	}
-
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
@@ -1,124 +1,124 @@
 package org.oddlama.vane.core;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.NotNull;
+import static java.nio.file.StandardWatchEventKinds.*;
 
 import java.io.*;
 import java.nio.file.*;
 import java.util.Iterator;
 import java.util.function.Predicate;
-
-import static java.nio.file.StandardWatchEventKinds.*;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
 public class ResourcePackFileWatcher {
 
-    private final ResourcePackDistributor resource_pack_distributor;
-    private final File file;
+	private final ResourcePackDistributor resource_pack_distributor;
+	private final File file;
 
-    @SuppressWarnings("unchecked")
-    public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file) throws IOException, InterruptedException {
-        this.resource_pack_distributor = resource_pack_distributor;
-        this.file = file;
-    }
+	@SuppressWarnings("unchecked")
+	public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file)
+		throws IOException, InterruptedException {
+		this.resource_pack_distributor = resource_pack_distributor;
+		this.file = file;
+	}
 
-    public void watch_for_changes() throws IOException {
-        var eyes = FileSystems.getDefault().newWatchService();
-        var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
-        register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
+	public void watch_for_changes() throws IOException {
+		var eyes = FileSystems.getDefault().newWatchService();
+		var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
+		register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
 
-        watch_async(eyes, lang_file_match, this::update_and_send_resource_pack).runTaskAsynchronously(resource_pack_distributor.get_module());
-    }
+		watch_async(eyes, lang_file_match, this::update_and_send_resource_pack)
+			.runTaskAsynchronously(resource_pack_distributor.get_module());
+	}
 
-    private void update_and_send_resource_pack() {
-        resource_pack_distributor.counter++;
-        resource_pack_distributor.get_module().generate_resource_pack();
-        resource_pack_distributor.update_sha1(file);
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            resource_pack_distributor.send_resource_pack(player);
-        }
-    }
+	private void update_and_send_resource_pack() {
+		resource_pack_distributor.counter++;
+		resource_pack_distributor.get_module().generate_resource_pack();
+		resource_pack_distributor.update_sha1(file);
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			resource_pack_distributor.send_resource_pack(player);
+		}
+	}
 
-    private boolean is_vane_module_folder(Path p) {
-        return p.getFileName().toString().startsWith("vane-");
-    }
+	private boolean is_vane_module_folder(Path p) {
+		return p.getFileName().toString().startsWith("vane-");
+	}
 
-    private static class TrackRunned extends BukkitRunnable {
+	private static class TrackRunned extends BukkitRunnable {
 
-        final Runnable r;
-        boolean has_run = false;
-        boolean has_started = false;
+		final Runnable r;
+		boolean has_run = false;
+		boolean has_started = false;
 
-        public TrackRunned(Runnable r) {
-            this.r = r;
-        }
+		public TrackRunned(Runnable r) {
+			this.r = r;
+		}
 
-        @Override
-        public void run() {
-            has_started = true;
-            r.run();
-            has_run = true;
-        }
-    }
+		@Override
+		public void run() {
+			has_started = true;
+			r.run();
+			has_run = true;
+		}
+	}
 
-    private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
-        return new BukkitRunnable() {
-            @Override
-            public void run() {
-                boolean should_schedule = false;
-                TrackRunned runner = null;
-                for (; ; ) {
-                    final WatchKey key;
-                    try {
-                        key = eyes.take();
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    // process events
-                    for (WatchEvent<?> event : key.pollEvents()) {
-                        if (event.kind() == OVERFLOW) continue;
+	private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
+		return new BukkitRunnable() {
+			@Override
+			public void run() {
+				boolean should_schedule = false;
+				TrackRunned runner = null;
+				for (;;) {
+					final WatchKey key;
+					try {
+						key = eyes.take();
+					} catch (InterruptedException e) {
+						throw new RuntimeException(e);
+					}
+					// process events
+					for (WatchEvent<?> event : key.pollEvents()) {
+						if (event.kind() == OVERFLOW) continue;
 
-                        // This generic is always Path for WatchEvent kinds other than OVERFLOW
-                        @SuppressWarnings("unchecked")
-                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
-                        Path dir = (Path) key.watchable();
-                        Path filename = ev.context();
-                        if (!match_lang.matches(dir.resolve(filename))) continue;
-                        should_schedule = true;
-                    }
+						// This generic is always Path for WatchEvent kinds other than OVERFLOW
+						@SuppressWarnings("unchecked")
+						WatchEvent<Path> ev = (WatchEvent<Path>) event;
+						Path dir = (Path) key.watchable();
+						Path filename = ev.context();
+						if (!match_lang.matches(dir.resolve(filename))) continue;
+						should_schedule = true;
+					}
 
-                    if (should_schedule) {
-                        if (runner != null) {
-                            if (!runner.has_started) runner.cancel();
-                        }
-                        runner = new TrackRunned(on_hit);
-                        runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
-                        should_schedule = false;
-                    }
+					if (should_schedule) {
+						if (runner != null) {
+							if (!runner.has_started) runner.cancel();
+						}
+						runner = new TrackRunned(on_hit);
+						runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
+						should_schedule = false;
+					}
 
-                    // reset the key
-                    boolean valid = key.reset();
-                    if (!valid) {
-                        return;
-                    }
-                }
-            }
-        };
-    }
+					// reset the key
+					boolean valid = key.reset();
+					if (!valid) {
+						return;
+					}
+				}
+			}
+		};
+	}
 
-    private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match)
-            throws IOException {
-        // register vane sub-folders.
-        final Iterator<Path> interesting_paths = Files
-                .walk(root)
-                .filter(Files::isDirectory)
-                .filter(path_match)
-                .iterator();
-        // quirky, but checked exceptions inside streams suck.
-        while (interesting_paths.hasNext()) {
-            Path p = interesting_paths.next();
-            p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
-        }
-    }
+	private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match) throws IOException {
+		// register vane sub-folders.
+		final Iterator<Path> interesting_paths = Files
+			.walk(root)
+			.filter(Files::isDirectory)
+			.filter(path_match)
+			.iterator();
+		// quirky, but checked exceptions inside streams suck.
+		while (interesting_paths.hasNext()) {
+			Path p = interesting_paths.next();
+			p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+		}
+	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
@@ -1,0 +1,124 @@
+package org.oddlama.vane.core;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+
+public class ResourcePackFileWatcher {
+
+    private final ResourcePackDistributor resource_pack_distributor;
+    private final File file;
+
+    @SuppressWarnings("unchecked")
+    public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file) throws IOException, InterruptedException {
+        this.resource_pack_distributor = resource_pack_distributor;
+        this.file = file;
+    }
+
+    public void watch_for_changes() throws IOException {
+        var eyes = FileSystems.getDefault().newWatchService();
+        var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
+        register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
+
+        watch_async(eyes, lang_file_match, this::update_and_send_resource_pack).runTaskAsynchronously(resource_pack_distributor.get_module());
+    }
+
+    private void update_and_send_resource_pack() {
+        resource_pack_distributor.counter++;
+        resource_pack_distributor.get_module().generate_resource_pack();
+        resource_pack_distributor.update_sha1(file);
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            resource_pack_distributor.send_resource_pack(player);
+        }
+    }
+
+    private boolean is_vane_module_folder(Path p) {
+        return p.getFileName().toString().startsWith("vane-");
+    }
+
+    private static class TrackRunned extends BukkitRunnable {
+
+        final Runnable r;
+        boolean has_run = false;
+        boolean has_started = false;
+
+        public TrackRunned(Runnable r) {
+            this.r = r;
+        }
+
+        @Override
+        public void run() {
+            has_started = true;
+            r.run();
+            has_run = true;
+        }
+    }
+
+    private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                boolean should_schedule = false;
+                TrackRunned runner = null;
+                for (; ; ) {
+                    final WatchKey key;
+                    try {
+                        key = eyes.take();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    // process events
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        if (event.kind() == OVERFLOW) continue;
+
+                        // This generic is always Path for WatchEvent kinds other than OVERFLOW
+                        @SuppressWarnings("unchecked")
+                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                        Path dir = (Path) key.watchable();
+                        Path filename = ev.context();
+                        if (!match_lang.matches(dir.resolve(filename))) continue;
+                        should_schedule = true;
+                    }
+
+                    if (should_schedule) {
+                        if (runner != null) {
+                            if (!runner.has_started) runner.cancel();
+                        }
+                        runner = new TrackRunned(on_hit);
+                        runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
+                        should_schedule = false;
+                    }
+
+                    // reset the key
+                    boolean valid = key.reset();
+                    if (!valid) {
+                        return;
+                    }
+                }
+            }
+        };
+    }
+
+    private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match)
+            throws IOException {
+        // register vane sub-folders.
+        final Iterator<Path> interesting_paths = Files
+                .walk(root)
+                .filter(Files::isDirectory)
+                .filter(path_match)
+                .iterator();
+        // quirky, but checked exceptions inside streams suck.
+        while (interesting_paths.hasNext()) {
+            Path p = interesting_paths.next();
+            p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        }
+    }
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/YamlLoadException.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/YamlLoadException.java
@@ -1,9 +1,47 @@
 package org.oddlama.vane.core;
 
+import org.oddlama.vane.core.lang.LangField;
+
 @SuppressWarnings("serial")
 public class YamlLoadException extends Exception {
 
 	public YamlLoadException(String message) {
 		super(message);
+	}
+
+	public YamlLoadException() {
+		super();
+	}
+
+	public YamlLoadException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public YamlLoadException(Throwable cause) {
+		super(cause);
+	}
+
+	protected YamlLoadException(
+		String message,
+		Throwable cause,
+		boolean enableSuppression,
+		boolean writableStackTrace
+	) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public static class Lang extends YamlLoadException {
+
+		public final LangField<?> langField;
+
+		@Override
+		public String getMessage() {
+			return "[" + this.langField.toString() + "] " + super.getMessage();
+		}
+
+		public <T> Lang(String message, LangField<?> erroredField) {
+			super(message);
+			this.langField = erroredField;
+		}
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/commands/Vane.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/commands/Vane.java
@@ -1,6 +1,7 @@
 package org.oddlama.vane.core.commands;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.oddlama.vane.annotation.command.Name;
 import org.oddlama.vane.annotation.lang.LangMessage;
 import org.oddlama.vane.core.Core;
@@ -52,10 +53,16 @@ public class Vane extends Command<Core> {
 	}
 
 	private void generate_resource_pack(CommandSender sender) {
-		if (get_module().generate_resource_pack()) {
-			lang_resource_pack_generate_success.send(sender);
+		var file = get_module().generate_resource_pack();
+		if (file != null) {
+			lang_resource_pack_generate_success.send(sender, file.getAbsolutePath());
 		} else {
 			lang_resource_pack_generate_fail.send(sender);
+		}
+		if (sender instanceof Player) {
+			var dist = get_module().resource_pack_distributor;
+			dist.update_sha1(file);
+			dist.send_resource_pack((Player) sender);
 		}
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangField.java
@@ -9,6 +9,8 @@ import org.oddlama.vane.core.module.Module;
 
 public abstract class LangField<T> {
 
+	public static final String PREFIX = "lang_";
+
 	private Module<?> module;
 	protected Object owner;
 	protected Field field;
@@ -20,7 +22,11 @@ public abstract class LangField<T> {
 		this.module = module;
 		this.owner = owner;
 		this.field = field;
-		this.name = map_name.apply(field.getName().substring("lang_".length()));
+
+		if (!field.getName().contains(PREFIX)) throw new RuntimeException(
+			new YamlLoadException.Lang("field must start with " + PREFIX, this)
+		);
+		this.name = map_name.apply(field.getName().substring(PREFIX.length()));
 		this.namespace = module.namespace();
 		this.key = namespace + "." + yaml_path();
 
@@ -37,7 +43,7 @@ public abstract class LangField<T> {
 
 	protected void check_yaml_path(YamlConfiguration yaml) throws YamlLoadException {
 		if (!yaml.contains(name, true)) {
-			throw new YamlLoadException("yaml is missing entry with path '" + name + "'");
+			throw new YamlLoadException.Lang("yaml is missing entry with path '" + name + "'", this);
 		}
 	}
 
@@ -70,5 +76,10 @@ public abstract class LangField<T> {
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Invalid field access on '" + field.getName() + "'. This is a bug.");
 		}
+	}
+
+	@Override
+	public String toString() {
+		return (field.getDeclaringClass().getTypeName() + "::" + field.getName());
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageArrayField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageArrayField.java
@@ -30,12 +30,15 @@ public class LangMessageArrayField extends LangField<TranslatedMessageArray> {
 		check_yaml_path(yaml);
 
 		if (!yaml.isList(yaml_path())) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected list");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected list", this);
 		}
 
 		for (final var obj : yaml.getList(yaml_path())) {
 			if (!(obj instanceof String)) {
-				throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected string");
+				throw new YamlLoadException.Lang(
+					"Invalid type for yaml path '" + yaml_path() + "', expected string",
+					this
+				);
 			}
 		}
 	}
@@ -64,11 +67,12 @@ public class LangMessageArrayField extends LangField<TranslatedMessageArray> {
 		final var list = from_yaml(yaml);
 		final var loaded_size = get().size();
 		if (list.size() != loaded_size) {
-			throw new YamlLoadException(
+			throw new YamlLoadException.Lang(
 				"All translation lists for message arrays must have the exact same size. The loaded language file has " +
 				loaded_size +
 				" entries, while the currently processed file has " +
-				list.size()
+				list.size(),
+				this
 			);
 		}
 		for (int i = 0; i < list.size(); ++i) {

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageField.java
@@ -28,7 +28,7 @@ public class LangMessageField extends LangField<TranslatedMessage> {
 		check_yaml_path(yaml);
 
 		if (!yaml.isString(yaml_path())) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected string");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected string", this);
 		}
 	}
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangVersionField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangVersionField.java
@@ -28,12 +28,15 @@ public class LangVersionField extends LangField<Long> {
 		check_yaml_path(yaml);
 
 		if (!(yaml.get(yaml_path()) instanceof Number)) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected long");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected long", this);
 		}
 
 		var val = yaml.getLong(yaml_path());
 		if (val < 1) {
-			throw new YamlLoadException("Entry '" + yaml_path() + "' has an invalid value: Value must be >= 1");
+			throw new YamlLoadException.Lang(
+				"Entry '" + yaml_path() + "' has an invalid value: Value must be >= 1",
+				this
+			);
 		}
 	}
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/module/Module.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/module/Module.java
@@ -278,10 +278,12 @@ public abstract class Module<T extends Module<T>> extends JavaPlugin implements 
 			.forEach(lang_file -> {
 				final var yaml = YamlConfiguration.loadConfiguration(lang_file);
 				try {
-					lang_manager.generate_resource_pack(pack, yaml);
+					lang_manager.generate_resource_pack(pack, yaml, lang_file);
 				} catch (Exception e) {
-					log.severe("Error while generating language for '" + lang_file + "' of module " + get_name());
-					throw e;
+					throw new RuntimeException(
+						"Error while generating language for '" + lang_file + "' of module " + get_name(),
+						e
+					);
 				}
 			});
 

--- a/vane-core/src/main/resources/lang-en.yml
+++ b/vane-core/src/main/resources/lang-en.yml
@@ -45,7 +45,7 @@ command_vane:
   # %1$s: module
   reload_fail: "%1$s§7: §creload failed"
   # This message is sent when the resource_pack has been successfully generated.
-  resource_pack_generate_success: "§aResource pack generated successfully"
+  resource_pack_generate_success: "§aResource pack generated successfully: %1$s"
   # This message is sent when the resource_pack could not be generated.
   resource_pack_generate_fail: "§cAn error has occurred while generating the resource pack"
   usage: "%1$s §7<§areload§7|§agenerate_resource_pack§7>"


### PR DESCRIPTION
This is a QoL improvement for developers who are developing vane.

It adds 
1. Several gradle tasks, for ease of cleaning up the paper-run workspace.
2. Better logging for the generation of translation files from the annotation.
3. A very barebones simple http server, capable of only serving single files.
4. A file watcher, which recompiles the resource pack when changes are detected to *runtime* translation files in the run/vane-* directory.

I believe the examples I showed in discord of errors I have made should be enough to show why this is useful :-).

p.s. I'm sorry about the spotty commit history, I'm trying to make a habit of cleaner development, but it was being developed in parallel with the soulbound changes,.