### PR TITLE
Feature: Home & Unstable scroll Durability & Improvements.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,5 +121,43 @@ configure(subprojects.filter {
 
 runPaper {
 	disablePluginJarDetection()
+}
 
+tasks.create<Delete>("cleanVaneRuntimeTranslations") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/lang-*.yml")
+	})
+}
+
+tasks.create<Delete>("cleanVaneConfigurations") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/config.yml")
+	})
+}
+
+tasks.create<Delete>("cleanVaneStorage") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/storage.json")
+	})
+}
+
+tasks.create<Delete>("cleanVane") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include("plugins/vane-*/")
+	})
+}
+
+tasks.create<Delete>("cleanWorld") {
+	group = "run paper"
+	delete(fileTree("run").matching {
+		include(
+				"world",
+				"world_nether",
+				"world_the_end"
+		)
+	})
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ java {
 	sourceCompatibility = JavaVersion.VERSION_17
 }
 
+// Common settings to all subprojects.
 subprojects {
 	apply(plugin = "java-library")
 	apply(plugin = "java")
@@ -50,6 +51,7 @@ subprojects {
 	}
 }
 
+// All Paper Plugins + Annotations.
 configure(subprojects.filter {
 	!listOf("vane-waterfall").contains(it.name)
 }) {
@@ -66,6 +68,7 @@ configure(subprojects.filter {
 	 }
 }
 
+// All Projects except waterfall and annotations.
 configure(subprojects.filter {
 	!listOf("vane-annotations", "vane-waterfall").contains(it.name)
 }) {
@@ -94,22 +97,32 @@ configure(subprojects.filter {
 	}
 
 	rootProject.tasks.runMojangMappedServer {
+		// the input to reobf, is the mojmapped jars.
 		pluginJars(tasks.named<io.papermc.paperweight.tasks.RemapJar>("reobfJar").flatMap { it.inputJar })
 	}
 
 	rootProject.tasks.runServer {
+		// the output is the obfuscated jars.
 		pluginJars(tasks.named<io.papermc.paperweight.tasks.RemapJar>("reobfJar").flatMap { it.outputJar })
 	}
 }
 
+// All paper plugins except core.
 configure(subprojects.filter {
 	!listOf("vane-annotations", "vane-core", "vane-waterfall").contains(it.name)
 }) {
 	dependencies {
+		// https://imperceptiblethoughts.com/shadow/multi-project/#depending-on-the-shadow-jar-from-another-project
+		// In a multi-project build there may be one project that applies Shadow and another that requires the shadowed
+		// JAR as a dependency. In this case, use Gradle's normal dependency declaration mechanism to depend on the
+		// shadow configuration of the shadowed project.
 		implementation(project(path = ":vane-core", configuration = "shadow"))
+		// But also depend on core itself.
+		implementation(project(path = ":vane-core"))
 	}
 }
 
+// All plugins with map integration
 configure(subprojects.filter {
 	listOf("vane-bedtime", "vane-portals", "vane-regions").contains(it.name)
 }) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,10 @@ pluginManagement {
 
 rootProject.name = "vane"
 
+// https://docs.gradle.org/current/dsl/org.gradle.api.initialization.Settings.html
+// Adds the given projects to the build. Each path in the supplied list is treated as the path of a project to add to
+// the build. Note that these path are not file paths, but instead specify the location of the new project in the
+// project hierarchy. As such, the supplied paths must use the ':' character as separator (and NOT '/').
 include(":vane-admin")
 include(":vane-annotations")
 include(":vane-bedtime")

--- a/vane-core/src/main/java/org/oddlama/vane/core/Core.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/Core.java
@@ -100,6 +100,8 @@ public class Core extends Module<Core> implements PluginMessageListener {
 	// Module registry
 	private SortedSet<Module<?>> vane_modules = new TreeSet<>((a, b) -> a.get_name().compareTo(b.get_name()));
 
+	public final ResourcePackDistributor resource_pack_distributor;
+
 	public void register_module(Module<?> module) {
 		vane_modules.add(module);
 	}
@@ -164,7 +166,7 @@ public class Core extends Module<Core> implements PluginMessageListener {
 		new org.oddlama.vane.core.commands.Vane(this);
 		new org.oddlama.vane.core.commands.CustomItem(this);
 		menu_manager = new MenuManager(this);
-		new ResourcePackDistributor(this);
+		resource_pack_distributor = new ResourcePackDistributor(this);
 		new CommandHider(this);
 	}
 
@@ -217,8 +219,9 @@ public class Core extends Module<Core> implements PluginMessageListener {
 		getServer().getMessenger().unregisterIncomingPluginChannel(this, CHANNEL_AUTH_MULTIPLEX, this);
 	}
 
-	public boolean generate_resource_pack() {
+	public File generate_resource_pack() {
 		try {
+			var file = new File("vane-resource-pack.zip");
 			var pack = new ResourcePackGenerator();
 			pack.set_description("Vane plugin resource pack");
 			pack.set_icon_png(getResource("pack.png"));
@@ -227,12 +230,12 @@ public class Core extends Module<Core> implements PluginMessageListener {
 				m.generate_resource_pack(pack);
 			}
 
-			pack.write(new File("vane-resource-pack.zip"));
+			pack.write(file);
+			return file;
 		} catch (Exception e) {
 			log.log(Level.SEVERE, "Error while generating resourcepack", e);
-			return false;
+			return null;
 		}
-		return true;
 	}
 
 	public void for_all_module_components(final Consumer1<ModuleComponent<?>> f) {

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
@@ -1,0 +1,67 @@
+package org.oddlama.vane.core;
+
+import com.google.common.hash.Hashing;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class ResourcePackDevServer implements HttpHandler {
+
+    private final ResourcePackDistributor resource_pack_distributor;
+    private final File file;
+
+    public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
+        this.resource_pack_distributor = resource_pack_distributor;
+        this.file = file;
+    }
+
+    public void serve() {
+        try {
+            final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
+            var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
+            resource_pack_distributor.sha1 = hash.toString();
+            resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
+
+            httpServer.createContext("/", this);
+            httpServer.setExecutor(null);
+            httpServer.start();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void handle(HttpExchange he) throws IOException {
+        String method = he.getRequestMethod();
+        if (!("HEAD".equals(method) || "GET".equals(method))) {
+            he.sendResponseHeaders(501, -1);
+            return;
+        }
+
+        FileInputStream fis;
+        try {
+            fis = new FileInputStream(file);
+        } catch (FileNotFoundException e) {
+            he.sendResponseHeaders(404, -1);
+            return;
+        }
+
+        he.getResponseHeaders().set("Content-Type", "application/zip");
+        if ("GET".equals(method)) {
+            he.sendResponseHeaders(200, file.length());
+            OutputStream os = he.getResponseBody();
+            fis.transferTo(os);
+            os.close();
+        } else {
+            assert ("HEAD".equals(method));
+            he.sendResponseHeaders(200, -1);
+        }
+        fis.close();
+    }
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDevServer.java
@@ -4,7 +4,6 @@ import com.google.common.hash.Hashing;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -14,54 +13,54 @@ import java.net.InetSocketAddress;
 
 public class ResourcePackDevServer implements HttpHandler {
 
-    private final ResourcePackDistributor resource_pack_distributor;
-    private final File file;
+	private final ResourcePackDistributor resource_pack_distributor;
+	private final File file;
 
-    public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
-        this.resource_pack_distributor = resource_pack_distributor;
-        this.file = file;
-    }
+	public ResourcePackDevServer(ResourcePackDistributor resource_pack_distributor, File file) {
+		this.resource_pack_distributor = resource_pack_distributor;
+		this.file = file;
+	}
 
-    public void serve() {
-        try {
-            final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
-            var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
-            resource_pack_distributor.sha1 = hash.toString();
-            resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
+	public void serve() {
+		try {
+			final HttpServer httpServer = HttpServer.create(new InetSocketAddress(9000), 0);
+			var hash = com.google.common.io.Files.asByteSource(this.file).hash(Hashing.sha1());
+			resource_pack_distributor.sha1 = hash.toString();
+			resource_pack_distributor.url = "http://localhost:9000/vane-resource-pack.zip";
 
-            httpServer.createContext("/", this);
-            httpServer.setExecutor(null);
-            httpServer.start();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
+			httpServer.createContext("/", this);
+			httpServer.setExecutor(null);
+			httpServer.start();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
 
-    public void handle(HttpExchange he) throws IOException {
-        String method = he.getRequestMethod();
-        if (!("HEAD".equals(method) || "GET".equals(method))) {
-            he.sendResponseHeaders(501, -1);
-            return;
-        }
+	public void handle(HttpExchange he) throws IOException {
+		String method = he.getRequestMethod();
+		if (!("HEAD".equals(method) || "GET".equals(method))) {
+			he.sendResponseHeaders(501, -1);
+			return;
+		}
 
-        FileInputStream fis;
-        try {
-            fis = new FileInputStream(file);
-        } catch (FileNotFoundException e) {
-            he.sendResponseHeaders(404, -1);
-            return;
-        }
+		FileInputStream fis;
+		try {
+			fis = new FileInputStream(file);
+		} catch (FileNotFoundException e) {
+			he.sendResponseHeaders(404, -1);
+			return;
+		}
 
-        he.getResponseHeaders().set("Content-Type", "application/zip");
-        if ("GET".equals(method)) {
-            he.sendResponseHeaders(200, file.length());
-            OutputStream os = he.getResponseBody();
-            fis.transferTo(os);
-            os.close();
-        } else {
-            assert ("HEAD".equals(method));
-            he.sendResponseHeaders(200, -1);
-        }
-        fis.close();
-    }
+		he.getResponseHeaders().set("Content-Type", "application/zip");
+		if ("GET".equals(method)) {
+			he.sendResponseHeaders(200, file.length());
+			OutputStream os = he.getResponseBody();
+			fis.transferTo(os);
+			os.close();
+		} else {
+			assert ("HEAD".equals(method));
+			he.sendResponseHeaders(200, -1);
+		}
+		fis.close();
+	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDistributor.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackDistributor.java
@@ -2,11 +2,9 @@ package org.oddlama.vane.core;
 
 import com.google.common.hash.Hashing;
 import com.google.common.io.Files;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
-
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -175,5 +173,4 @@ public class ResourcePackDistributor extends Listener<Core> {
 			ResourcePackDistributor.this.sha1 = hash.toString();
 		} catch (IOException ignored) {}
 	}
-
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
@@ -1,124 +1,124 @@
 package org.oddlama.vane.core;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
-import org.bukkit.scheduler.BukkitRunnable;
-import org.jetbrains.annotations.NotNull;
+import static java.nio.file.StandardWatchEventKinds.*;
 
 import java.io.*;
 import java.nio.file.*;
 import java.util.Iterator;
 import java.util.function.Predicate;
-
-import static java.nio.file.StandardWatchEventKinds.*;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
 
 public class ResourcePackFileWatcher {
 
-    private final ResourcePackDistributor resource_pack_distributor;
-    private final File file;
+	private final ResourcePackDistributor resource_pack_distributor;
+	private final File file;
 
-    @SuppressWarnings("unchecked")
-    public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file) throws IOException, InterruptedException {
-        this.resource_pack_distributor = resource_pack_distributor;
-        this.file = file;
-    }
+	@SuppressWarnings("unchecked")
+	public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file)
+		throws IOException, InterruptedException {
+		this.resource_pack_distributor = resource_pack_distributor;
+		this.file = file;
+	}
 
-    public void watch_for_changes() throws IOException {
-        var eyes = FileSystems.getDefault().newWatchService();
-        var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
-        register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
+	public void watch_for_changes() throws IOException {
+		var eyes = FileSystems.getDefault().newWatchService();
+		var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
+		register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
 
-        watch_async(eyes, lang_file_match, this::update_and_send_resource_pack).runTaskAsynchronously(resource_pack_distributor.get_module());
-    }
+		watch_async(eyes, lang_file_match, this::update_and_send_resource_pack)
+			.runTaskAsynchronously(resource_pack_distributor.get_module());
+	}
 
-    private void update_and_send_resource_pack() {
-        resource_pack_distributor.counter++;
-        resource_pack_distributor.get_module().generate_resource_pack();
-        resource_pack_distributor.update_sha1(file);
-        for (Player player : Bukkit.getOnlinePlayers()) {
-            resource_pack_distributor.send_resource_pack(player);
-        }
-    }
+	private void update_and_send_resource_pack() {
+		resource_pack_distributor.counter++;
+		resource_pack_distributor.get_module().generate_resource_pack();
+		resource_pack_distributor.update_sha1(file);
+		for (Player player : Bukkit.getOnlinePlayers()) {
+			resource_pack_distributor.send_resource_pack(player);
+		}
+	}
 
-    private boolean is_vane_module_folder(Path p) {
-        return p.getFileName().toString().startsWith("vane-");
-    }
+	private boolean is_vane_module_folder(Path p) {
+		return p.getFileName().toString().startsWith("vane-");
+	}
 
-    private static class TrackRunned extends BukkitRunnable {
+	private static class TrackRunned extends BukkitRunnable {
 
-        final Runnable r;
-        boolean has_run = false;
-        boolean has_started = false;
+		final Runnable r;
+		boolean has_run = false;
+		boolean has_started = false;
 
-        public TrackRunned(Runnable r) {
-            this.r = r;
-        }
+		public TrackRunned(Runnable r) {
+			this.r = r;
+		}
 
-        @Override
-        public void run() {
-            has_started = true;
-            r.run();
-            has_run = true;
-        }
-    }
+		@Override
+		public void run() {
+			has_started = true;
+			r.run();
+			has_run = true;
+		}
+	}
 
-    private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
-        return new BukkitRunnable() {
-            @Override
-            public void run() {
-                boolean should_schedule = false;
-                TrackRunned runner = null;
-                for (; ; ) {
-                    final WatchKey key;
-                    try {
-                        key = eyes.take();
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    // process events
-                    for (WatchEvent<?> event : key.pollEvents()) {
-                        if (event.kind() == OVERFLOW) continue;
+	private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
+		return new BukkitRunnable() {
+			@Override
+			public void run() {
+				boolean should_schedule = false;
+				TrackRunned runner = null;
+				for (;;) {
+					final WatchKey key;
+					try {
+						key = eyes.take();
+					} catch (InterruptedException e) {
+						throw new RuntimeException(e);
+					}
+					// process events
+					for (WatchEvent<?> event : key.pollEvents()) {
+						if (event.kind() == OVERFLOW) continue;
 
-                        // This generic is always Path for WatchEvent kinds other than OVERFLOW
-                        @SuppressWarnings("unchecked")
-                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
-                        Path dir = (Path) key.watchable();
-                        Path filename = ev.context();
-                        if (!match_lang.matches(dir.resolve(filename))) continue;
-                        should_schedule = true;
-                    }
+						// This generic is always Path for WatchEvent kinds other than OVERFLOW
+						@SuppressWarnings("unchecked")
+						WatchEvent<Path> ev = (WatchEvent<Path>) event;
+						Path dir = (Path) key.watchable();
+						Path filename = ev.context();
+						if (!match_lang.matches(dir.resolve(filename))) continue;
+						should_schedule = true;
+					}
 
-                    if (should_schedule) {
-                        if (runner != null) {
-                            if (!runner.has_started) runner.cancel();
-                        }
-                        runner = new TrackRunned(on_hit);
-                        runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
-                        should_schedule = false;
-                    }
+					if (should_schedule) {
+						if (runner != null) {
+							if (!runner.has_started) runner.cancel();
+						}
+						runner = new TrackRunned(on_hit);
+						runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
+						should_schedule = false;
+					}
 
-                    // reset the key
-                    boolean valid = key.reset();
-                    if (!valid) {
-                        return;
-                    }
-                }
-            }
-        };
-    }
+					// reset the key
+					boolean valid = key.reset();
+					if (!valid) {
+						return;
+					}
+				}
+			}
+		};
+	}
 
-    private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match)
-            throws IOException {
-        // register vane sub-folders.
-        final Iterator<Path> interesting_paths = Files
-                .walk(root)
-                .filter(Files::isDirectory)
-                .filter(path_match)
-                .iterator();
-        // quirky, but checked exceptions inside streams suck.
-        while (interesting_paths.hasNext()) {
-            Path p = interesting_paths.next();
-            p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
-        }
-    }
+	private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match) throws IOException {
+		// register vane sub-folders.
+		final Iterator<Path> interesting_paths = Files
+			.walk(root)
+			.filter(Files::isDirectory)
+			.filter(path_match)
+			.iterator();
+		// quirky, but checked exceptions inside streams suck.
+		while (interesting_paths.hasNext()) {
+			Path p = interesting_paths.next();
+			p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+		}
+	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/ResourcePackFileWatcher.java
@@ -1,0 +1,124 @@
+package org.oddlama.vane.core;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.*;
+import java.nio.file.*;
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+import static java.nio.file.StandardWatchEventKinds.*;
+
+public class ResourcePackFileWatcher {
+
+    private final ResourcePackDistributor resource_pack_distributor;
+    private final File file;
+
+    @SuppressWarnings("unchecked")
+    public ResourcePackFileWatcher(ResourcePackDistributor resource_pack_distributor, File file) throws IOException, InterruptedException {
+        this.resource_pack_distributor = resource_pack_distributor;
+        this.file = file;
+    }
+
+    public void watch_for_changes() throws IOException {
+        var eyes = FileSystems.getDefault().newWatchService();
+        var lang_file_match = FileSystems.getDefault().getPathMatcher("glob:**/lang-*.yml");
+        register_directories(Paths.get("plugins"), eyes, this::is_vane_module_folder);
+
+        watch_async(eyes, lang_file_match, this::update_and_send_resource_pack).runTaskAsynchronously(resource_pack_distributor.get_module());
+    }
+
+    private void update_and_send_resource_pack() {
+        resource_pack_distributor.counter++;
+        resource_pack_distributor.get_module().generate_resource_pack();
+        resource_pack_distributor.update_sha1(file);
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            resource_pack_distributor.send_resource_pack(player);
+        }
+    }
+
+    private boolean is_vane_module_folder(Path p) {
+        return p.getFileName().toString().startsWith("vane-");
+    }
+
+    private static class TrackRunned extends BukkitRunnable {
+
+        final Runnable r;
+        boolean has_run = false;
+        boolean has_started = false;
+
+        public TrackRunned(Runnable r) {
+            this.r = r;
+        }
+
+        @Override
+        public void run() {
+            has_started = true;
+            r.run();
+            has_run = true;
+        }
+    }
+
+    private @NotNull BukkitRunnable watch_async(WatchService eyes, PathMatcher match_lang, Runnable on_hit) {
+        return new BukkitRunnable() {
+            @Override
+            public void run() {
+                boolean should_schedule = false;
+                TrackRunned runner = null;
+                for (; ; ) {
+                    final WatchKey key;
+                    try {
+                        key = eyes.take();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    // process events
+                    for (WatchEvent<?> event : key.pollEvents()) {
+                        if (event.kind() == OVERFLOW) continue;
+
+                        // This generic is always Path for WatchEvent kinds other than OVERFLOW
+                        @SuppressWarnings("unchecked")
+                        WatchEvent<Path> ev = (WatchEvent<Path>) event;
+                        Path dir = (Path) key.watchable();
+                        Path filename = ev.context();
+                        if (!match_lang.matches(dir.resolve(filename))) continue;
+                        should_schedule = true;
+                    }
+
+                    if (should_schedule) {
+                        if (runner != null) {
+                            if (!runner.has_started) runner.cancel();
+                        }
+                        runner = new TrackRunned(on_hit);
+                        runner.runTaskLater(resource_pack_distributor.get_module().core, 20L);
+                        should_schedule = false;
+                    }
+
+                    // reset the key
+                    boolean valid = key.reset();
+                    if (!valid) {
+                        return;
+                    }
+                }
+            }
+        };
+    }
+
+    private void register_directories(Path root, WatchService watcher, Predicate<Path> path_match)
+            throws IOException {
+        // register vane sub-folders.
+        final Iterator<Path> interesting_paths = Files
+                .walk(root)
+                .filter(Files::isDirectory)
+                .filter(path_match)
+                .iterator();
+        // quirky, but checked exceptions inside streams suck.
+        while (interesting_paths.hasNext()) {
+            Path p = interesting_paths.next();
+            p.register(watcher, ENTRY_CREATE, ENTRY_DELETE, ENTRY_MODIFY);
+        }
+    }
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/YamlLoadException.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/YamlLoadException.java
@@ -1,9 +1,47 @@
 package org.oddlama.vane.core;
 
+import org.oddlama.vane.core.lang.LangField;
+
 @SuppressWarnings("serial")
 public class YamlLoadException extends Exception {
 
 	public YamlLoadException(String message) {
 		super(message);
+	}
+
+	public YamlLoadException() {
+		super();
+	}
+
+	public YamlLoadException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public YamlLoadException(Throwable cause) {
+		super(cause);
+	}
+
+	protected YamlLoadException(
+		String message,
+		Throwable cause,
+		boolean enableSuppression,
+		boolean writableStackTrace
+	) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+
+	public static class Lang extends YamlLoadException {
+
+		public final LangField<?> langField;
+
+		@Override
+		public String getMessage() {
+			return "[" + this.langField.toString() + "] " + super.getMessage();
+		}
+
+		public <T> Lang(String message, LangField<?> erroredField) {
+			super(message);
+			this.langField = erroredField;
+		}
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/commands/Vane.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/commands/Vane.java
@@ -1,6 +1,7 @@
 package org.oddlama.vane.core.commands;
 
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.oddlama.vane.annotation.command.Name;
 import org.oddlama.vane.annotation.lang.LangMessage;
 import org.oddlama.vane.core.Core;
@@ -52,10 +53,16 @@ public class Vane extends Command<Core> {
 	}
 
 	private void generate_resource_pack(CommandSender sender) {
-		if (get_module().generate_resource_pack()) {
-			lang_resource_pack_generate_success.send(sender);
+		var file = get_module().generate_resource_pack();
+		if (file != null) {
+			lang_resource_pack_generate_success.send(sender, file.getAbsolutePath());
 		} else {
 			lang_resource_pack_generate_fail.send(sender);
+		}
+		if (sender instanceof Player) {
+			var dist = get_module().resource_pack_distributor;
+			dist.update_sha1(file);
+			dist.send_resource_pack((Player) sender);
 		}
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/data/CooldownData.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/data/CooldownData.java
@@ -1,0 +1,52 @@
+package org.oddlama.vane.core.data;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataHolder;
+import org.bukkit.persistence.PersistentDataType;
+
+public class CooldownData {
+
+	private final NamespacedKey key;
+	private final long cooldown_time;
+
+	public CooldownData(NamespacedKey key, long cooldown_time) {
+		this.key = key;
+		this.cooldown_time = cooldown_time;
+	}
+
+	/**
+	 * Updates the cooldown data, if and only if the cooldown has been exceeded.
+	 * @return returns true if cooldown_time has been exceeded.
+	 */
+	public boolean check_or_update_cooldown(final PersistentDataHolder holder) {
+		final var persistent_data = holder.getPersistentDataContainer();
+		final var last_time = persistent_data.getOrDefault(key, PersistentDataType.LONG, 0L);
+		final var now = System.currentTimeMillis();
+		if (now - last_time < cooldown_time) {
+			return false;
+		}
+
+		persistent_data.set(key, PersistentDataType.LONG, now);
+		return true;
+	}
+
+	/**
+	 * @return Gets the status of the cooldown without updating
+	 */
+	public boolean peek_cooldown(PersistentDataHolder holder) {
+		PersistentDataContainer persistent_data = holder.getPersistentDataContainer();
+		Long last_time = persistent_data.getOrDefault(this.key, PersistentDataType.LONG, 0L);
+		long now = System.currentTimeMillis();
+		if (now - last_time < this.cooldown_time) {
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	public void clear(final PersistentDataHolder holder) {
+		final var persistent_data = holder.getPersistentDataContainer();
+		persistent_data.remove(key);
+	}
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/data/DurabilityOverrideData.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/data/DurabilityOverrideData.java
@@ -1,0 +1,200 @@
+package org.oddlama.vane.core.data;
+
+import static org.oddlama.vane.util.ItemUtil.damage_item;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.Style;
+import net.kyori.adventure.text.format.TextDecoration;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerItemMendEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.oddlama.vane.util.Util;
+
+public class DurabilityOverrideData {
+
+	private final NamespacedKey key_max;
+	private static final PersistentDataType<Integer, Integer> type_max = PersistentDataType.INTEGER;
+	private final NamespacedKey key_damage;
+	private static final PersistentDataType<Integer, Integer> type_damage = PersistentDataType.INTEGER;
+	private final int max_durability;
+	private static final Style TOOLTIP_STYLE = Style
+		.style(NamedTextColor.WHITE)
+		.decoration(TextDecoration.ITALIC, TextDecoration.State.FALSE);
+	private static final TranslatableComponent DURABILITY_TOOLTIP = Component
+		.translatable("item.durability")
+		.style(TOOLTIP_STYLE);
+
+	public DurabilityOverrideData(int max_durability) {
+		this(
+			Util.namespaced_key("vane", "durability.max"),
+			Util.namespaced_key("vane", "durability.damage"),
+			max_durability
+		);
+	}
+
+	DurabilityOverrideData(NamespacedKey key_max, NamespacedKey key_damage, int max_durability) {
+		this.key_max = key_max;
+		this.key_damage = key_damage;
+		this.max_durability = max_durability;
+	}
+
+	public int max(final ItemStack stack) {
+		return stack.getItemMeta().getPersistentDataContainer().getOrDefault(key_max, type_max, max_durability);
+	}
+
+	public void max(final ItemStack stack, int max) {
+		modifying(stack, pdc -> pdc.set(key_max, type_max, max));
+	}
+
+	public int damage(final ItemStack stack) {
+		Damageable dmg = stack.getItemMeta() instanceof Damageable ? (Damageable) stack.getItemMeta() : null;
+		var default_value = dmg == null ? 0 : dmg.getDamage();
+		return stack.getItemMeta().getPersistentDataContainer().getOrDefault(key_damage, type_damage, default_value);
+	}
+
+	public void damage(final ItemStack stack, int current) {
+		modifying(stack, pdc -> pdc.set(key_damage, type_damage, current));
+	}
+
+	private static void modifying(ItemStack stack, Consumer<PersistentDataContainer> worker) {
+		var meta = stack.getItemMeta();
+		var pdc = meta.getPersistentDataContainer();
+		worker.accept(pdc);
+		stack.setItemMeta(meta);
+	}
+
+	/**
+	 * *Always* updates the item's fake durability lore + data values.
+	 * forces the player to use the item, potentially causing damage if enchantments allow.
+	 * @return if the item was damaged.
+	 */
+	public boolean use_item(final Player player, final ItemStack stack) {
+		final ItemMeta itemMeta = stack.getItemMeta();
+		if (!(itemMeta instanceof Damageable)) return false;
+
+		var real_global_max = stack.getType().getMaxDurability();
+		var before_damage = ((Damageable) stack.getItemMeta()).getDamage();
+		var fake_individual_max = this.max(stack);
+		var fake_damage = this.damage(stack);
+
+		damage_item(player, stack, 1);
+
+		Integer after_damage = null;
+		if ((stack.getItemMeta() instanceof Damageable)) {
+			after_damage = ((Damageable) stack.getItemMeta()).getDamage();
+		}
+		if (after_damage == null) return true; //Thing broke.
+
+		var diff = after_damage - before_damage;
+		// track the 'real' dmg
+		int new_damage = fake_damage + diff;
+		damage(stack, new_damage);
+		var technically_correct_percent = float_division(new_damage, fake_individual_max);
+		float dangerous_interpolated_damage = technically_correct_percent * real_global_max;
+		// We need to clamp it above 0, so the item doesn't randomly break.
+		var safe_damage = custom_clamp(new_damage, fake_individual_max, dangerous_interpolated_damage, real_global_max);
+		final Damageable itemMeta1 = ((Damageable) stack.getItemMeta());
+		itemMeta1.setDamage(safe_damage);
+		update_lore(itemMeta1, new_damage, fake_individual_max);
+		stack.setItemMeta(itemMeta1);
+		return diff != 0;
+	}
+
+	private void update_lore(ItemMeta itemMeta1, int dmg, int max) {
+		var lore = itemMeta1.lore();
+		final boolean found_lore = lore != null && lore.stream().anyMatch(this::matches);
+
+		List<Component> new_lore = lore;
+		if (new_lore == null) new_lore = Lists.newArrayList();
+
+		if (found_lore) {
+			new_lore =
+				lore
+					.stream()
+					.flatMap(l -> {
+						if (matches(l)) {
+							if (itemMeta1.isUnbreakable()) return Stream.empty();
+							return Stream.of(update_lore(l, max - dmg, max));
+						} else {
+							return Stream.of(l);
+						}
+					})
+					.toList();
+		} else {
+			new_lore.add(create_lore(max - dmg, max));
+		}
+		itemMeta1.lore(new_lore);
+	}
+
+	protected Component create_lore(int uses_remaining, int max) {
+		return DURABILITY_TOOLTIP.args(Component.text(uses_remaining), Component.text(max));
+	}
+
+	protected Component update_lore(Component lore, int uses_remaining, int max) {
+		// Stop those pesky overshoots looking so derpy.
+		// only possible with desyncs / config changes anyway.
+		uses_remaining = Math.max(1, Math.min(uses_remaining, max));
+		return ((TranslatableComponent) lore).args(Component.text(uses_remaining), Component.text(max));
+	}
+
+	protected boolean matches(Component a) {
+		if (!(a instanceof TranslatableComponent a_as_TC)) return false;
+		return DURABILITY_TOOLTIP.key().equals(a_as_TC.key());
+	}
+
+	/**
+	 * clamp the display value on the following rules.
+	 * IFF and only if there is 1 durability remaining, the output is will reflect that (max-1 damage).
+	 * IFF the item is unused, the output is 0.
+	 * If the item is consumed, the output is max.
+	 * This is to support better emulation of modded client side warnings or datapacks if the tool is about to break etc.
+	 */
+	private int custom_clamp(int fake_damage, int fake_max, float dangerous_interpolated_damage, short max) {
+		// This can only happen in weird edgecases, in which case we recover by breaking the item the next time
+		// the player uses it. Much better then showing negative values in the fake durability lore.
+		if (fake_damage >= fake_max) return max - 1;
+		if (fake_damage == fake_max) return max;
+		if (fake_damage == fake_max - 1) return max - 1;
+		if (fake_damage == 0) return 0;
+		return clamp(dangerous_interpolated_damage, 1, max - 2);
+	}
+
+	private static int clamp(float f, int min, int max) {
+		var out = Math.round(f);
+		return Math.min(max, Math.max(min, out));
+	}
+
+	private static float float_division(float top, float bottom) {
+		return top / bottom;
+	}
+
+	public void clear(final ItemStack itemStack) {
+		modifying(
+			itemStack,
+			pdc -> {
+				pdc.remove(key_damage);
+				pdc.remove(key_max);
+			}
+		);
+		var lore = itemStack.lore();
+		if (lore != null) lore.remove(DURABILITY_TOOLTIP);
+		itemStack.lore(lore);
+	}
+
+	public void on_mend(PlayerItemMendEvent mend) {
+		// TODO: Durability Overridden items can not yet support mending effectively.
+		// see: https://github.com/PaperMC/Paper/issues/7313
+		mend.setCancelled(true);
+	}
+}

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemVariant.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemVariant.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.core.item;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +15,7 @@ import org.oddlama.vane.core.ResourcePackGenerator;
 import org.oddlama.vane.core.lang.TranslatedMessage;
 import org.oddlama.vane.core.module.Module;
 import org.oddlama.vane.core.module.ModuleComponent;
+import org.oddlama.vane.util.Util;
 
 public class CustomItemVariant<T extends Module<T>, V extends CustomItem<T, V>, U extends ItemVariantEnum>
 	extends ModuleComponent<T> {
@@ -50,7 +49,7 @@ public class CustomItemVariant<T extends Module<T>, V extends CustomItem<T, V>, 
 		}
 
 		// Create namespaced_key
-		this.key = namespaced_key(get_module().namespace(), variant_name);
+		this.key = Util.namespaced_key(get_module().namespace(), variant_name);
 
 		// Check for duplicate model data
 		parent.check_valid_model_data(this);
@@ -94,7 +93,7 @@ public class CustomItemVariant<T extends Module<T>, V extends CustomItem<T, V>, 
 	 * Returns the namespaced key for this item with additional suffix.
 	 */
 	public final NamespacedKey key(String suffix) {
-		return namespaced_key(get_module().namespace(), variant_name + "_" + suffix);
+		return Util.namespaced_key(get_module().namespace(), variant_name + "_" + suffix);
 	}
 
 	public final String variant_name() {
@@ -144,9 +143,9 @@ public class CustomItemVariant<T extends Module<T>, V extends CustomItem<T, V>, 
 	/** Returns a named recipe key */
 	public final NamespacedKey recipe_key(String recipe_name) {
 		if (recipe_name.equals("")) {
-			return namespaced_key(get_module().namespace(), variant_name + "_recipe");
+			return Util.namespaced_key(get_module().namespace(), variant_name + "_recipe");
 		}
-		return namespaced_key(get_module().namespace(), variant_name + "_recipe_" + recipe_name);
+		return Util.namespaced_key(get_module().namespace(), variant_name + "_recipe_" + recipe_name);
 	}
 
 	private final void add_recipe_or_throw(NamespacedKey recipe_key, Recipe recipe) {

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangField.java
@@ -9,6 +9,8 @@ import org.oddlama.vane.core.module.Module;
 
 public abstract class LangField<T> {
 
+	public static final String PREFIX = "lang_";
+
 	private Module<?> module;
 	protected Object owner;
 	protected Field field;
@@ -20,7 +22,11 @@ public abstract class LangField<T> {
 		this.module = module;
 		this.owner = owner;
 		this.field = field;
-		this.name = map_name.apply(field.getName().substring("lang_".length()));
+
+		if (!field.getName().contains(PREFIX)) throw new RuntimeException(
+			new YamlLoadException.Lang("field must start with " + PREFIX, this)
+		);
+		this.name = map_name.apply(field.getName().substring(PREFIX.length()));
 		this.namespace = module.namespace();
 		this.key = namespace + "." + yaml_path();
 
@@ -37,7 +43,7 @@ public abstract class LangField<T> {
 
 	protected void check_yaml_path(YamlConfiguration yaml) throws YamlLoadException {
 		if (!yaml.contains(name, true)) {
-			throw new YamlLoadException("yaml is missing entry with path '" + name + "'");
+			throw new YamlLoadException.Lang("yaml is missing entry with path '" + name + "'", this);
 		}
 	}
 
@@ -70,5 +76,10 @@ public abstract class LangField<T> {
 		} catch (IllegalAccessException e) {
 			throw new RuntimeException("Invalid field access on '" + field.getName() + "'. This is a bug.");
 		}
+	}
+
+	@Override
+	public String toString() {
+		return (field.getDeclaringClass().getTypeName() + "::" + field.getName());
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageArrayField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageArrayField.java
@@ -30,12 +30,15 @@ public class LangMessageArrayField extends LangField<TranslatedMessageArray> {
 		check_yaml_path(yaml);
 
 		if (!yaml.isList(yaml_path())) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected list");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected list", this);
 		}
 
 		for (final var obj : yaml.getList(yaml_path())) {
 			if (!(obj instanceof String)) {
-				throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected string");
+				throw new YamlLoadException.Lang(
+					"Invalid type for yaml path '" + yaml_path() + "', expected string",
+					this
+				);
 			}
 		}
 	}
@@ -64,11 +67,12 @@ public class LangMessageArrayField extends LangField<TranslatedMessageArray> {
 		final var list = from_yaml(yaml);
 		final var loaded_size = get().size();
 		if (list.size() != loaded_size) {
-			throw new YamlLoadException(
+			throw new YamlLoadException.Lang(
 				"All translation lists for message arrays must have the exact same size. The loaded language file has " +
 				loaded_size +
 				" entries, while the currently processed file has " +
-				list.size()
+				list.size(),
+				this
 			);
 		}
 		for (int i = 0; i < list.size(); ++i) {

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangMessageField.java
@@ -28,7 +28,7 @@ public class LangMessageField extends LangField<TranslatedMessage> {
 		check_yaml_path(yaml);
 
 		if (!yaml.isString(yaml_path())) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected string");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected string", this);
 		}
 	}
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/LangVersionField.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/LangVersionField.java
@@ -28,12 +28,15 @@ public class LangVersionField extends LangField<Long> {
 		check_yaml_path(yaml);
 
 		if (!(yaml.get(yaml_path()) instanceof Number)) {
-			throw new YamlLoadException("Invalid type for yaml path '" + yaml_path() + "', expected long");
+			throw new YamlLoadException.Lang("Invalid type for yaml path '" + yaml_path() + "', expected long", this);
 		}
 
 		var val = yaml.getLong(yaml_path());
 		if (val < 1) {
-			throw new YamlLoadException("Entry '" + yaml_path() + "' has an invalid value: Value must be >= 1");
+			throw new YamlLoadException.Lang(
+				"Entry '" + yaml_path() + "' has an invalid value: Value must be >= 1",
+				this
+			);
 		}
 	}
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/lang/TranslatedMessage.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/lang/TranslatedMessage.java
@@ -97,6 +97,14 @@ public class TranslatedMessage {
 		}
 	}
 
+	public void send_action_bar(final CommandSender sender, Object... args) {
+		if (sender == null || sender == module.getServer().getConsoleSender()) {
+			module.log.info(str(args));
+		} else {
+			sender.sendActionBar(format(args));
+		}
+	}
+
 	public void send_and_log(final CommandSender sender, Object... args) {
 		module.log.info(str(args));
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/module/Module.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/module/Module.java
@@ -278,10 +278,12 @@ public abstract class Module<T extends Module<T>> extends JavaPlugin implements 
 			.forEach(lang_file -> {
 				final var yaml = YamlConfiguration.loadConfiguration(lang_file);
 				try {
-					lang_manager.generate_resource_pack(pack, yaml);
+					lang_manager.generate_resource_pack(pack, yaml, lang_file);
 				} catch (Exception e) {
-					log.severe("Error while generating language for '" + lang_file + "' of module " + get_name());
-					throw e;
+					throw new RuntimeException(
+						"Error while generating language for '" + lang_file + "' of module " + get_name(),
+						e
+					);
 				}
 			});
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/module/ModuleComponent.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/module/ModuleComponent.java
@@ -2,6 +2,8 @@ package org.oddlama.vane.core.module;
 
 import java.io.IOException;
 import java.util.function.Consumer;
+
+import org.bukkit.NamespacedKey;
 import org.bukkit.scheduler.BukkitTask;
 import org.json.JSONObject;
 import org.oddlama.vane.core.ResourcePackGenerator;
@@ -68,5 +70,9 @@ public abstract class ModuleComponent<T extends Module<T>> {
 
 	public final void mark_persistent_storage_dirty() {
 		context.mark_persistent_storage_dirty();
+	}
+
+	public final NamespacedKey namespaced_key(String value) {
+		return new NamespacedKey(get_module(), get_context().variable_yaml_path(value));
 	}
 }

--- a/vane-core/src/main/java/org/oddlama/vane/core/module/ModuleComponent.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/module/ModuleComponent.java
@@ -2,7 +2,6 @@ package org.oddlama.vane.core.module;
 
 import java.io.IOException;
 import java.util.function.Consumer;
-
 import org.bukkit.NamespacedKey;
 import org.bukkit.scheduler.BukkitTask;
 import org.json.JSONObject;

--- a/vane-core/src/main/resources/lang-en.yml
+++ b/vane-core/src/main/resources/lang-en.yml
@@ -45,7 +45,7 @@ command_vane:
   # %1$s: module
   reload_fail: "%1$s§7: §creload failed"
   # This message is sent when the resource_pack has been successfully generated.
-  resource_pack_generate_success: "§aResource pack generated successfully"
+  resource_pack_generate_success: "§aResource pack generated successfully: %1$s"
   # This message is sent when the resource_pack could not be generated.
   resource_pack_generate_fail: "§cAn error has occurred while generating the resource pack"
   usage: "%1$s §7<§areload§7|§agenerate_resource_pack§7>"

--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/CustomEnchantment.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/CustomEnchantment.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.enchantments;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/CustomEnchantment.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/CustomEnchantment.java
@@ -24,6 +24,7 @@ import org.oddlama.vane.core.lang.TranslatedMessage;
 import org.oddlama.vane.core.module.Context;
 import org.oddlama.vane.core.module.Module;
 import org.oddlama.vane.util.Nms;
+import org.oddlama.vane.util.Util;
 
 public class CustomEnchantment<T extends Module<T>> extends Listener<T> {
 
@@ -53,7 +54,7 @@ public class CustomEnchantment<T extends Module<T>> extends Listener<T> {
 		set_context(context);
 
 		// Create namespaced key
-		key = namespaced_key(get_module().namespace(), name);
+		key = Util.namespaced_key(get_module().namespace(), name);
 
 		// Check if instance is already exists
 		if (instances.get(getClass()) != null) {
@@ -287,9 +288,9 @@ public class CustomEnchantment<T extends Module<T>> extends Listener<T> {
 	/** Returns a named recipe key */
 	public final NamespacedKey recipe_key(String recipe_name) {
 		if (recipe_name.equals("")) {
-			return namespaced_key(get_module().namespace(), "enchantment_" + name + "_recipe");
+			return Util.namespaced_key(get_module().namespace(), "enchantment_" + name + "_recipe");
 		}
-		return namespaced_key(get_module().namespace(), "enchantment_" + name + "_recipe_" + recipe_name);
+		return Util.namespaced_key(get_module().namespace(), "enchantment_" + name + "_recipe_" + recipe_name);
 	}
 
 	private final void add_recipe_or_throw(NamespacedKey recipe_key, Recipe recipe) {

--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.enchantments.enchantments;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.util.ArrayList;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -193,7 +191,10 @@ public class Soulbound extends CustomEnchantment<Enchantments> {
 			if (inventory.firstEmpty() != -1) {
 				// We still have space in the inventory, so the player tried to drop it with Q.
 				event.setCancelled(true);
-				lang_drop_lock_warning.send_action_bar(event.getPlayer(), event.getItemDrop().getItemStack().displayName());
+				lang_drop_lock_warning.send_action_bar(
+					event.getPlayer(),
+					event.getItemDrop().getItemStack().displayName()
+				);
 			} else {
 				// Inventory is full (e.g. when exiting crafting table with soulbound item in it)
 				// so we drop the first non-soulbound item (if any) instead.

--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
@@ -1,22 +1,33 @@
 package org.oddlama.vane.enchantments.enchantments;
 
+import static org.oddlama.vane.util.Util.namespaced_key;
+
 import java.util.ArrayList;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryAction;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.loot.LootTables;
+import org.oddlama.vane.annotation.config.ConfigLong;
 import org.oddlama.vane.annotation.enchantment.Rarity;
 import org.oddlama.vane.annotation.enchantment.VaneEnchantment;
+import org.oddlama.vane.annotation.lang.LangMessage;
 import org.oddlama.vane.core.LootTable.LootTableEntry;
+import org.oddlama.vane.core.data.CooldownData;
 import org.oddlama.vane.core.item.CustomItem;
+import org.oddlama.vane.core.lang.TranslatedMessage;
 import org.oddlama.vane.core.module.Context;
 import org.oddlama.vane.enchantments.CustomEnchantment;
 import org.oddlama.vane.enchantments.Enchantments;
@@ -26,8 +37,36 @@ import org.oddlama.vane.enchantments.items.BookVariant;
 @VaneEnchantment(name = "soulbound", rarity = Rarity.RARE, treasure = true, allow_custom = true)
 public class Soulbound extends CustomEnchantment<Enchantments> {
 
+	@ConfigLong(
+		def = 2000,
+		min = 0,
+		desc = "Window to allow Soulbound item drop immediately after a previous drop in milliseconds"
+	)
+	public long config_cooldown;
+
+	private static final NamespacedKey IGNORE_SOULBOUND_DROP = namespaced_key(
+		"vane_enchantments",
+		"ignore_soulbound_drop"
+	);
+	private CooldownData drop_cooldown = new CooldownData(IGNORE_SOULBOUND_DROP, config_cooldown);
+
+	@LangMessage
+	public TranslatedMessage lang_drop_lock_warning;
+
+	@LangMessage
+	public TranslatedMessage lang_dropped_notification;
+
+	@LangMessage
+	public TranslatedMessage lang_drop_cooldown;
+
 	public Soulbound(Context<Enchantments> context) {
 		super(context);
+	}
+
+	@Override
+	public void on_config_change() {
+		super.on_config_change();
+		drop_cooldown = new CooldownData(IGNORE_SOULBOUND_DROP, config_cooldown);
 	}
 
 	@Override
@@ -105,10 +144,32 @@ public class Soulbound extends CustomEnchantment<Enchantments> {
 		final var it = event.getDrops().iterator();
 		while (it.hasNext()) {
 			final var drop = it.next();
-			if (drop.getEnchantmentLevel(this.bukkit()) > 0) {
+			if (is_soulbound(drop)) {
 				keep_items.add(drop);
 				it.remove();
 			}
+		}
+	}
+
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void on_player_inventory_check(final InventoryClickEvent event) {
+		if (event.getCursor() == null) return;
+		if (!is_soulbound(event.getCursor())) return;
+		if (
+			event.getAction() == InventoryAction.DROP_ALL_CURSOR || event.getAction() == InventoryAction.DROP_ONE_CURSOR
+		) {
+			boolean too_slow = drop_cooldown.peek_cooldown(event.getCursor().getItemMeta());
+			if (too_slow) {
+				// Dropped too slow, refresh and cancel
+				final ItemMeta meta = event.getCursor().getItemMeta();
+				drop_cooldown.check_or_update_cooldown(meta);
+				event.getCursor().setItemMeta(meta);
+				lang_drop_cooldown.send_action_bar(event.getWhoClicked());
+				event.setResult(Event.Result.DENY);
+				return;
+			}
+			return;
+			// else allow as normal
 		}
 	}
 
@@ -118,11 +179,20 @@ public class Soulbound extends CustomEnchantment<Enchantments> {
 		// Prevents yeeting your best sword out of existence.
 		// (It's okay to put them into chests)
 		final var dropped_item = event.getItemDrop().getItemStack();
-		if (dropped_item.getEnchantmentLevel(this.bukkit()) > 0) {
+		if (is_soulbound(dropped_item)) {
+			boolean too_slow = drop_cooldown.peek_cooldown(dropped_item.getItemMeta());
+			if (!too_slow) {
+				var meta = dropped_item.getItemMeta();
+				drop_cooldown.clear(dropped_item.getItemMeta());
+				dropped_item.setItemMeta(meta);
+				lang_dropped_notification.send(event.getPlayer(), dropped_item.displayName());
+				return;
+			}
 			final var inventory = event.getPlayer().getInventory();
 			if (inventory.firstEmpty() != -1) {
 				// We still have space in the inventory, so the player tried to drop it with Q.
 				event.setCancelled(true);
+				lang_drop_lock_warning.send_action_bar(event.getPlayer(), event.getItemDrop().getItemStack().displayName());
 			} else {
 				// Inventory is full (e.g. when exiting crafting table with soulbound item in it)
 				// so we drop the first non-soulbound item (if any) instead.
@@ -149,8 +219,13 @@ public class Soulbound extends CustomEnchantment<Enchantments> {
 				final var player = event.getPlayer();
 				inventory.setItem(non_soulbound_item_slot, dropped_item);
 				player.getLocation().getWorld().dropItem(player.getLocation(), non_soulbound_item);
+				lang_drop_lock_warning.send_action_bar(player, event.getItemDrop().getItemStack().displayName());
 				event.setCancelled(true);
 			}
 		}
+	}
+
+	private boolean is_soulbound(ItemStack dropped_item) {
+		return dropped_item.getEnchantmentLevel(this.bukkit()) > 0;
 	}
 }

--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Soulbound.java
@@ -33,6 +33,7 @@ import org.oddlama.vane.enchantments.CustomEnchantment;
 import org.oddlama.vane.enchantments.Enchantments;
 import org.oddlama.vane.enchantments.items.AncientTomeOfTheGods;
 import org.oddlama.vane.enchantments.items.BookVariant;
+import org.oddlama.vane.util.Util;
 
 @VaneEnchantment(name = "soulbound", rarity = Rarity.RARE, treasure = true, allow_custom = true)
 public class Soulbound extends CustomEnchantment<Enchantments> {
@@ -44,7 +45,7 @@ public class Soulbound extends CustomEnchantment<Enchantments> {
 	)
 	public long config_cooldown;
 
-	private static final NamespacedKey IGNORE_SOULBOUND_DROP = namespaced_key(
+	private static final NamespacedKey IGNORE_SOULBOUND_DROP = Util.namespaced_key(
 		"vane_enchantments",
 		"ignore_soulbound_drop"
 	);

--- a/vane-enchantments/src/main/resources/lang-de.yml
+++ b/vane-enchantments/src/main/resources/lang-de.yml
@@ -68,6 +68,9 @@ enchantment_seeding:
 
 enchantment_soulbound:
   name: "Seelengebunden"
+  drop_lock_warning: "Soulbound Items can only be dropped using mouse"
+  drop_cooldown: "Drop again to confirm drop"
+  dropped_notification: "Soulbound Item Dropped: %1$s"
 
 enchantment_take_off:
   name: "Abflug"

--- a/vane-enchantments/src/main/resources/lang-en.yml
+++ b/vane-enchantments/src/main/resources/lang-en.yml
@@ -76,6 +76,9 @@ enchantment_seeding:
 enchantment_soulbound:
   # The display name of this enchantment. Will be packed into a resource pack.
   name: "Soulbound"
+  drop_lock_warning: "Soulbound Items can only be dropped using mouse"
+  drop_cooldown: "Drop again to confirm drop"
+  dropped_notification: "Soulbound Item Dropped: %1$s"
 
 enchantment_take_off:
   # The display name of this enchantment. Will be packed into a resource pack.

--- a/vane-enchantments/src/main/resources/lang-fr-fr.yml
+++ b/vane-enchantments/src/main/resources/lang-fr-fr.yml
@@ -59,6 +59,9 @@ enchantment_seeding:
 
 enchantment_soulbound:
   name: "Lié à l'âme"
+  drop_lock_warning: "Soulbound Items can only be dropped using mouse"
+  drop_cooldown: "Drop again to confirm drop"
+  dropped_notification: "Soulbound Item Dropped: %1$s"
 
 enchantment_take_off:
   name: "Décollage"

--- a/vane-enchantments/src/main/resources/lang-ru.yml
+++ b/vane-enchantments/src/main/resources/lang-ru.yml
@@ -76,6 +76,9 @@ enchantment_seeding:
 enchantment_soulbound:
   # The display name of this enchantment. Will be packed into a resource pack.
   name: "Духовная связь"
+  drop_lock_warning: "Soulbound Items can only be dropped using mouse"
+  drop_cooldown: "Drop again to confirm drop"
+  dropped_notification: "Soulbound Item Dropped: %1$s"
 
 enchantment_take_off:
   # The display name of this enchantment. Will be packed into a resource pack.

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/menu/ConsoleMenu.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/menu/ConsoleMenu.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.portals.menu;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.util.Objects;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/menu/ConsoleMenu.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/menu/ConsoleMenu.java
@@ -27,6 +27,7 @@ import org.oddlama.vane.portals.event.PortalDestroyEvent;
 import org.oddlama.vane.portals.event.PortalSelectTargetEvent;
 import org.oddlama.vane.portals.event.PortalUnlinkConsoleEvent;
 import org.oddlama.vane.portals.portal.Portal;
+import org.oddlama.vane.util.Util;
 
 public class ConsoleMenu extends ModuleComponent<Portals> {
 
@@ -101,7 +102,7 @@ public class ConsoleMenu extends ModuleComponent<Portals> {
 			new TranslatedItemStack<>(
 				ctx,
 				"unlink_console",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to unlink the current console."
 			);
@@ -109,7 +110,7 @@ public class ConsoleMenu extends ModuleComponent<Portals> {
 			new TranslatedItemStack<>(
 				ctx,
 				"unlink_console_confirm_accept",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to confirm unlinking the current console."
 			);

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/menu/SettingsMenu.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/menu/SettingsMenu.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.portals.menu;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/menu/SettingsMenu.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/menu/SettingsMenu.java
@@ -21,6 +21,7 @@ import org.oddlama.vane.core.module.ModuleComponent;
 import org.oddlama.vane.portals.Portals;
 import org.oddlama.vane.portals.event.PortalChangeSettingsEvent;
 import org.oddlama.vane.portals.portal.Portal;
+import org.oddlama.vane.util.Util;
 
 public class SettingsMenu extends ModuleComponent<Portals> {
 
@@ -51,7 +52,7 @@ public class SettingsMenu extends ModuleComponent<Portals> {
 			new TranslatedItemStack<>(
 				ctx,
 				"select_icon",
-				namespaced_key("vane", "decoration_end_portal_orb"),
+				Util.namespaced_key("vane", "decoration_end_portal_orb"),
 				1,
 				"Used to select the portal's icon."
 			);

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionGroupMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionGroupMenu.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.regions.menu;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionGroupMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionGroupMenu.java
@@ -22,6 +22,7 @@ import org.oddlama.vane.regions.Regions;
 import org.oddlama.vane.regions.region.EnvironmentSetting;
 import org.oddlama.vane.regions.region.RegionGroup;
 import org.oddlama.vane.regions.region.Role;
+import org.oddlama.vane.util.Util;
 
 public class RegionGroupMenu extends ModuleComponent<Regions> {
 
@@ -64,7 +65,7 @@ public class RegionGroupMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to delete this region group."
 			);
@@ -72,7 +73,7 @@ public class RegionGroupMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete_confirm_accept",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to confirm deleting the region group."
 			);
@@ -123,7 +124,7 @@ public class RegionGroupMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"setting_info_animals",
-				namespaced_key("vane", "animals_baby_pig_2"),
+				Util.namespaced_key("vane", "animals_baby_pig_2"),
 				1,
 				"Used to represent the info for the animals setting."
 			);
@@ -139,7 +140,7 @@ public class RegionGroupMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"setting_info_explosions",
-				namespaced_key("vane", "monsters_creeper_with_tnt_2"),
+				Util.namespaced_key("vane", "monsters_creeper_with_tnt_2"),
 				1,
 				"Used to represent the info for the explosions setting."
 			);

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionMenu.java
@@ -1,7 +1,6 @@
 package org.oddlama.vane.regions.menu;
 
 import static org.oddlama.vane.util.PlayerUtil.give_items;
-import static org.oddlama.vane.util.Util.namespaced_key;
 
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RegionMenu.java
@@ -23,6 +23,7 @@ import org.oddlama.vane.regions.Regions;
 import org.oddlama.vane.regions.region.Region;
 import org.oddlama.vane.regions.region.RegionGroup;
 import org.oddlama.vane.regions.region.RegionSelection;
+import org.oddlama.vane.util.Util;
 
 public class RegionMenu extends ModuleComponent<Regions> {
 
@@ -53,7 +54,7 @@ public class RegionMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to delete this region."
 			);
@@ -61,7 +62,7 @@ public class RegionMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete_confirm_accept",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to confirm deleting the region."
 			);

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RoleMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RoleMenu.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.regions.menu;
 
-import static org.oddlama.vane.util.Util.namespaced_key;
-
 import java.util.stream.Collectors;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;

--- a/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RoleMenu.java
+++ b/vane-regions/src/main/java/org/oddlama/vane/regions/menu/RoleMenu.java
@@ -24,6 +24,7 @@ import org.oddlama.vane.regions.region.RegionGroup;
 import org.oddlama.vane.regions.region.Role;
 import org.oddlama.vane.regions.region.RoleSetting;
 import org.oddlama.vane.util.ItemUtil;
+import org.oddlama.vane.util.Util;
 
 public class RoleMenu extends ModuleComponent<Regions> {
 
@@ -66,7 +67,7 @@ public class RoleMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to delete this role."
 			);
@@ -74,7 +75,7 @@ public class RoleMenu extends ModuleComponent<Regions> {
 			new TranslatedItemStack<>(
 				ctx,
 				"delete_confirm_accept",
-				namespaced_key("vane", "decoration_tnt_1"),
+				Util.namespaced_key("vane", "decoration_tnt_1"),
 				1,
 				"Used to confirm deleting the role."
 			);

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/items/HomeScroll.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/items/HomeScroll.java
@@ -4,6 +4,8 @@ import static org.oddlama.vane.util.ItemUtil.damage_item;
 import static org.oddlama.vane.util.PlayerUtil.swing_arm;
 import static org.oddlama.vane.util.Util.ms_to_ticks;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.TranslatableComponent;
 import org.bukkit.Material;
 import org.bukkit.Tag;
 import org.bukkit.entity.Player;
@@ -122,7 +124,15 @@ public class HomeScroll extends CustomItem<Trifles, HomeScroll> {
 		}
 
 		final var to_location = player.getBedSpawnLocation();
+		final var to_potential_location = player.getPotentialBedLocation();
 		if (to_location == null) {
+			if(to_potential_location != null)
+				// The most cursed sentence in minecraft.
+				// "You have no home bed or charged respawn anchor, or it was obstructed"
+				player.sendActionBar(Component.translatable("block.minecraft.spawn.not_valid"));
+			else
+				//"Sleep in a bed to change your respawn point"
+				player.sendActionBar(Component.translatable("advancements.adventure.sleep_in_bed.description"));
 			return;
 		}
 


### PR DESCRIPTION
# Part 1:

https://youtu.be/abrylP-zHDs

Adds default minecraft translated elements to the action bar, to improve scroll first-use experience with new players.

(I may be giving them out as kits).

# Part 2:

Adds custom durability data for Home Scroll & Unstable Scroll, allowing the configuration to customize the amount of uses they have.

Also has lore showing the custom durability.

This combined with noticing that Mending tends to heal up the scroll really quickly, owing to it's low durability & Minecraft's default handing of mending, means that it is very difficult to fix the amount the item is repaired at the moment, without outright disabling it: https://github.com/PaperMC/Paper/issues/7313

## Technical Notes

The durability is emulated using Persistent Data nodes by monitoring the item for real durability changes, when we attempt to damage it. The lore is updated by searching for the translated component and changing it's arguments. This is how compatibility with unbreaking etc is achieved.

Whilst it does track the data, it is idempotent, so any desyncs will quickly be resolved the next time the item is used.

Changing the config retains the amount of uses the item has currently, but changes the maximum for existing items in the world.

Worst-case, it gives the user 2 extra uses of the item, if the new durability is less then the amount of total uses so far.

1 to resync the real durability, (making it 1 use remaining if the durability is invalid) and another to consume the item.

If there is 1 use remaining, we always force the real durability to 1 use remaining, this is so we can use the natural minecraft item break in regards to enchants.

This can be changed by storing the maximum when the item is first created, if desired.