### PR TITLE
Stop generating an empty jar for the root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,11 @@ java {
 	sourceCompatibility = JavaVersion.VERSION_17
 }
 
+// We don't need to generate an empty `vane.jar`
+tasks.withType<Jar> {
+	enabled = false
+}
+
 // Common settings to all subprojects.
 subprojects {
 	apply(plugin = "java-library")


### PR DESCRIPTION
Currently, building generates an empty jar at `build/libs/vane-dev.jar`. It serves no purpose, so it might as well just not be generated.