### PR TITLE
fix: invert DamageCause check 

### DIFF
--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Lightning.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/Lightning.java
@@ -100,7 +100,7 @@ public class Lightning extends CustomEnchantment<Enchantments> {
         if(!(event.getDamager() instanceof Player)) return;
 
         //if not an attack with a weapon exit
-        if(event.getCause()==DamageCause.ENTITY_ATTACK) return;
+        if(event.getCause()!=DamageCause.ENTITY_ATTACK) return;
 
         Player damager = (Player) event.getDamager();
         final var damagee = event.getEntity();


### PR DESCRIPTION
oops!  accidentally pushed one of my testing cases, this reverts the default lightning settings to only work on sword swings