### PR TITLE
fix: Move EntityMoveProcessor to portals module, only check entities in worlds with activated portals

### DIFF
--- a/vane-core/src/main/java/org/oddlama/vane/core/Core.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/Core.java
@@ -32,7 +32,6 @@ import org.oddlama.vane.core.lang.TranslatedMessage;
 import org.oddlama.vane.core.menu.MenuManager;
 import org.oddlama.vane.core.misc.AuthMultiplexer;
 import org.oddlama.vane.core.misc.CommandHider;
-import org.oddlama.vane.core.misc.EntityMoveProcessor;
 import org.oddlama.vane.core.misc.HeadLibrary;
 import org.oddlama.vane.core.misc.LootChestProtector;
 import org.oddlama.vane.core.module.Module;
@@ -126,7 +125,6 @@ public class Core extends Module<Core> {
 		// Components
 		enchantment_manager = new EnchantmentManager(this);
 		new HeadLibrary(this);
-		new EntityMoveProcessor(this);
 		new AuthMultiplexer(this);
 		new LootChestProtector(this);
 		new VanillaFunctionalityInhibitor(this);

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/PortalTeleporter.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/PortalTeleporter.java
@@ -17,7 +17,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
 import org.bukkit.event.player.PlayerPortalEvent;
 import org.bukkit.util.Vector;
 import org.oddlama.vane.core.Listener;
-import org.oddlama.vane.core.event.EntityMoveEvent;
+import org.oddlama.vane.portals.event.EntityMoveEvent;
 import org.oddlama.vane.core.module.Context;
 import org.oddlama.vane.portals.portal.Portal;
 import org.oddlama.vane.util.Nms;

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/Portals.java
@@ -257,6 +257,7 @@ public class Portals extends Module<Portals> {
 		new PortalBlockProtector(this);
 		constructor = new PortalConstructor(this);
 		new PortalTeleporter(this);
+		new EntityMoveProcessor(this);
 		dynmap_layer = new PortalDynmapLayer(this);
 		blue_map_layer = new PortalBlueMapLayer(this);
 		plexmap_layer = new PortalPlexMapLayer(this);

--- a/vane-portals/src/main/java/org/oddlama/vane/portals/event/EntityMoveEvent.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/event/EntityMoveEvent.java
@@ -1,4 +1,4 @@
-package org.oddlama.vane.core.event;
+package org.oddlama.vane.portals.event;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;


### PR DESCRIPTION
EntityMoveProcessor can be quite expensive and is only used for portals. Moving it to the portals module means the performance cost is only paid for servers that use portals. There's also no need to check for movement of all entities when no portals are activated - instead, only check entities in worlds with active portals.