### PR TITLE
Use correct permissions for Maintenance Command for velocity

### DIFF
--- a/vane-velocity/src/main/java/org/oddlama/velocity/commands/Maintenance.java
+++ b/vane-velocity/src/main/java/org/oddlama/velocity/commands/Maintenance.java
@@ -10,7 +10,7 @@ public class Maintenance implements SimpleCommand {
 	ProxyMaintenanceCommand cmd;
 
 	public Maintenance(final Velocity plugin) {
-		this.cmd = new ProxyMaintenanceCommand("vane_proxy.commands.ping", plugin);
+		this.cmd = new ProxyMaintenanceCommand("vane_proxy.commands.maintenance", plugin);
 	}
 
 	@Override


### PR DESCRIPTION
I noticed, that there is some kind of maintenance mode which (sometimes?) work. I just looked into the code and noticed, that those permissions are different that that from the waterfall version.

By the way, is there an overview for all Commands/Permissions?