### PR TITLE
fix: Stop portals in The End generating end gateway strucutres when used

### DIFF
--- a/vane-portals/src/main/java/org/oddlama/vane/portals/portal/Portal.java
+++ b/vane-portals/src/main/java/org/oddlama/vane/portals/portal/Portal.java
@@ -380,6 +380,13 @@ public class Portal {
 				final var end_gateway = (EndGateway) portal_block.block().getState(false);
 				end_gateway.setAge(200l);
 				end_gateway.update(true, false);
+
+				// If there's no exit location then the game will generate a natural gateway when the portal is used.
+				// Setting any location will do, since the teleports are cancelled via their events anyway.
+				if (spawn.location().getWorld().getEnvironment() == World.Environment.THE_END){
+					end_gateway.setExitLocation(spawn.location());
+					end_gateway.setExactTeleport(true);
+				}
 			}
 			if (portal_block.type() == PortalBlock.Type.CONSOLE) {
 				portals.update_console_item(this, portal_block.block());


### PR DESCRIPTION
If an entity touches an end gateway block in The End (or a world like it) which has no exit location set, the game will generate a new end gateway structure at the same angle relative to and 1024 or so blocks away from the origin (i.e. around the inner edge of the outer islands). Using a vane portal in an End world therefore creates a tower of gateways that grows each time the portal is used. This happens before Paper/Bukkit Entity/PlayerTeleportEndGatewayEvents are fired, so the existing cancelling of them doesn't prevent this. All the relevant logic is in `net.minecraft.world.level.block.entity.TheEndGatewayBlockEntity.teleportEntity`.

Setting an exit location for end gateway blocks in vane portals is enough to prevent this behaviour. Any location will do (I picked the portal's spawn since it was handy, and means at least one fewer allocation), since the teleport events being cancelled will prevent anything going there anyway.