### PR TITLE
ci: Don't try to build the removed plexmap module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: [ 'admin', 'bedtime', 'core', 'enchantments', 'permissions', 'plexmap', 'portals', 'regions', 'trifles', 'waterfall', 'velocity' ]
+        project: [ 'admin', 'bedtime', 'core', 'enchantments', 'permissions', 'portals', 'regions', 'trifles', 'waterfall', 'velocity' ]
 
     steps:
       - uses: actions/checkout@v3.0.0


### PR DESCRIPTION
The Pl3xMap module was removed in 00203e3, but CI still tries to build it and then the other jobs are cancelled when that fails.