### PR TITLE
feat: `max_damage` and `item_name` components support

### DIFF
--- a/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemHelper.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemHelper.java
@@ -2,6 +2,7 @@ package org.oddlama.vane.core.item;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.NamespacedKey;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
@@ -9,6 +10,10 @@ import org.jetbrains.annotations.Nullable;
 import org.oddlama.vane.core.Core;
 import org.oddlama.vane.core.item.api.CustomItem;
 import org.oddlama.vane.util.StorageUtil;
+
+import io.papermc.paper.adventure.PaperAdventure;
+import net.minecraft.core.component.DataComponentPatch;
+import net.minecraft.core.component.DataComponents;
 
 public class CustomItemHelper {
 	/** Used in persistent item storage to identify custom items. */
@@ -82,8 +87,10 @@ public class CustomItemHelper {
 	 */
 	public static ItemStack newStack(final CustomItem customItem, final int amount) {
 		final var itemStack = new ItemStack(customItem.baseMaterial(), amount);
-		itemStack.editMeta(meta -> meta.displayName(customItem.displayName()));
-		return CustomItemHelper.updateItemStack(customItem, itemStack);
+		final var itemStackNms = CraftItemStack.asNMSCopy(itemStack);
+		final var itemName = PaperAdventure.asVanilla(customItem.displayName());
+		itemStackNms.applyComponents(DataComponentPatch.builder().set(DataComponents.ITEM_NAME, itemName).build());
+		return CustomItemHelper.updateItemStack(customItem, itemStackNms.asBukkitMirror());
 	}
 
 	/**

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemHelper.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/CustomItemHelper.java
@@ -2,7 +2,6 @@ package org.oddlama.vane.core.item;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.NamespacedKey;
-import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
@@ -10,10 +9,6 @@ import org.jetbrains.annotations.Nullable;
 import org.oddlama.vane.core.Core;
 import org.oddlama.vane.core.item.api.CustomItem;
 import org.oddlama.vane.util.StorageUtil;
-
-import io.papermc.paper.adventure.PaperAdventure;
-import net.minecraft.core.component.DataComponentPatch;
-import net.minecraft.core.component.DataComponents;
 
 public class CustomItemHelper {
 	/** Used in persistent item storage to identify custom items. */
@@ -87,10 +82,8 @@ public class CustomItemHelper {
 	 */
 	public static ItemStack newStack(final CustomItem customItem, final int amount) {
 		final var itemStack = new ItemStack(customItem.baseMaterial(), amount);
-		final var itemStackNms = CraftItemStack.asNMSCopy(itemStack);
-		final var itemName = PaperAdventure.asVanilla(customItem.displayName());
-		itemStackNms.applyComponents(DataComponentPatch.builder().set(DataComponents.ITEM_NAME, itemName).build());
-		return CustomItemHelper.updateItemStack(customItem, itemStackNms.asBukkitMirror());
+		itemStack.editMeta(meta -> meta.itemName(customItem.displayName()));
+		return CustomItemHelper.updateItemStack(customItem, itemStack);
 	}
 
 	/**

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/DurabilityManager.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/DurabilityManager.java
@@ -109,6 +109,7 @@ public class DurabilityManager extends Listener<Core> {
 		}
 
 		set_damage_and_update_item(custom_item, item_stack, actual_damage);
+
 		return true;
 	}
 
@@ -123,7 +124,7 @@ public class DurabilityManager extends Listener<Core> {
 			return;
 		}
 
-		if(remove_old_damage(custom_item, item)){
+		if(remove_old_damage(custom_item, item) || update_damage(custom_item, item)){
 			item.editMeta(Damageable.class, damage_meta ->
 				damage_meta.setDamage(Math.max(0, damage_meta.getDamage() - event.getDamage())));
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/DurabilityManager.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/DurabilityManager.java
@@ -1,7 +1,5 @@
 package org.oddlama.vane.core.item;
 
-import java.util.ArrayList;
-
 import org.bukkit.NamespacedKey;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -68,7 +66,7 @@ public class DurabilityManager extends Listener<Core> {
 		final int finalDamage = damage;
 		item_stack.editMeta(Damageable.class, meta -> {
 			meta.setDamage(finalDamage);
-			meta.setMaxDamage(null);
+			meta.setMaxDamage(custom_item.durability());
 		});
 	}
 
@@ -139,7 +137,7 @@ public class DurabilityManager extends Listener<Core> {
 		if (!(item_stack.getItemMeta() instanceof Damageable meta))
 			return false; // everything should be damageable now
 		int old_max_damage = meta.hasMaxDamage() ? meta.getMaxDamage() : item_stack.getType().getMaxDurability();
-		int old_damage = meta.hasDamage() ? meta.getDamage() : old_max_damage;
+		int old_damage = meta.hasDamage() ? meta.getDamage() : 0;
 		float percentage = (float) old_damage / (float) old_max_damage;
 
 		final int max_damage = custom_item.durability() != 0
@@ -154,9 +152,6 @@ public class DurabilityManager extends Listener<Core> {
 			itemMeta.setMaxDamage(max_damage);
 			itemMeta.setDamage(Math.min(damage, max_damage));
 		});
-
-		// int oldDamage = meta.getPersistentDataContainer().get(ITEM_DURABILITY_DAMAGE,
-		// PersistentDataType.INTEGER);
 	}
 
 	/**
@@ -171,7 +166,7 @@ public class DurabilityManager extends Listener<Core> {
 
 		// get old values stored in the data
 		final int oldDamage = data.getOrDefault(ITEM_DURABILITY_DAMAGE, PersistentDataType.INTEGER, 0);
-		final int oldMaxDamage = data.getOrDefault(ITEM_DURABILITY_MAX, PersistentDataType.INTEGER, custom_item.durability());
+		final int oldMaxDamage = data.getOrDefault(ITEM_DURABILITY_MAX, PersistentDataType.INTEGER, custom_item.durability() == 0 ? item_stack.getType().getMaxDurability() : custom_item.durability());
 
 		final int newDamage = oldMaxDamage == custom_item.durability()
 			? oldDamage // to avoid precision errors on bigger numbers

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/ExistingItemConverter.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/ExistingItemConverter.java
@@ -113,18 +113,11 @@ public class ExistingItemConverter extends Listener<Core> {
 			Damageable damageableMeta = (Damageable) contents[i].getItemMeta();
 			int max_damage = damageableMeta.hasMaxDamage() ? damageableMeta.getMaxDamage() : contents[i].getType().getMaxDurability();
 			int correct_max_damage = custom_item.durability() == 0 ? contents[i].getType().getMaxDurability() : custom_item.durability();
-			if (max_damage != correct_max_damage) {
+			if (max_damage != correct_max_damage || meta.getPersistentDataContainer().has(DurabilityManager.ITEM_DURABILITY_DAMAGE)) {
 				get_module().log.info("Updated item durability " + custom_item.key());
 				DurabilityManager.update_damage(custom_item, contents[i]);
 				++changed;
 				continue;
-			}
-
-			// Update custom durability to vanilla one
-			if(meta.getPersistentDataContainer().has(DurabilityManager.ITEM_DURABILITY_DAMAGE)) {
-				get_module().log.info("Updated item durability mechanic " + custom_item.key());
-				DurabilityManager.remove_old_damage(custom_item, contents[i]);
-				++changed;
 			}
 		}
 

--- a/vane-core/src/main/java/org/oddlama/vane/core/item/ExistingItemConverter.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/item/ExistingItemConverter.java
@@ -7,7 +7,7 @@ import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.inventory.meta.Damageable;
 import org.jetbrains.annotations.NotNull;
 import org.oddlama.vane.core.Core;
 import org.oddlama.vane.core.Listener;
@@ -80,7 +80,7 @@ public class ExistingItemConverter extends Listener<Core> {
 				}
 
 				contents[i] = convert_to_custom_item.convertExistingStack(is);
-				contents[i].editMeta(meta -> meta.displayName(convert_to_custom_item.displayName()));
+				contents[i].editMeta(meta -> meta.itemName(convert_to_custom_item.displayName()));
 				get_module().enchantment_manager.update_enchanted_item(contents[i]);
 				get_module().log.info("Converted legacy item to " + convert_to_custom_item.key());
 				++changed;
@@ -110,9 +110,20 @@ public class ExistingItemConverter extends Listener<Core> {
 			}
 
 			// Update maximum durability on existing items if changed.
-			if (meta.getPersistentDataContainer().getOrDefault(DurabilityManager.ITEM_DURABILITY_MAX, PersistentDataType.INTEGER, 0) != custom_item.durability()) {
+			Damageable damageableMeta = (Damageable) contents[i].getItemMeta();
+			int max_damage = damageableMeta.hasMaxDamage() ? damageableMeta.getMaxDamage() : contents[i].getType().getMaxDurability();
+			int correct_max_damage = custom_item.durability() == 0 ? contents[i].getType().getMaxDurability() : custom_item.durability();
+			if (max_damage != correct_max_damage) {
 				get_module().log.info("Updated item durability " + custom_item.key());
-				DurabilityManager.initialize_or_update_max(custom_item, contents[i]);
+				DurabilityManager.update_damage(custom_item, contents[i]);
+				++changed;
+				continue;
+			}
+
+			// Update custom durability to vanilla one
+			if(meta.getPersistentDataContainer().has(DurabilityManager.ITEM_DURABILITY_DAMAGE)) {
+				get_module().log.info("Updated item durability mechanic " + custom_item.key());
+				DurabilityManager.remove_old_damage(custom_item, contents[i]);
 				++changed;
 			}
 		}

--- a/vane-core/src/main/java/org/oddlama/vane/util/ItemUtil.java
+++ b/vane-core/src/main/java/org/oddlama/vane/util/ItemUtil.java
@@ -11,19 +11,16 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import com.destroystokyo.paper.profile.ProfileProperty;
-import com.mojang.brigadier.StringReader;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.craftbukkit.enchantments.CraftEnchantment;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -31,6 +28,10 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.oddlama.vane.core.Core;
 import org.oddlama.vane.core.material.ExtendedMaterial;
+
+import com.destroystokyo.paper.profile.ProfileProperty;
+import com.mojang.brigadier.StringReader;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -40,8 +41,6 @@ import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.item.ItemParser;
-import net.minecraft.core.HolderLookup;
-import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.item.Item;
@@ -55,9 +54,11 @@ public class ItemUtil {
 	public static final UUID MODIFIER_UUID_GENERIC_ATTACK_SPEED = UUID.fromString(
 			"FA233E1C-4180-4865-B01B-BCCE9785ACA3");
 
-	private static RandomSource randomSource = RandomSource.create();
-
 	public static void damage_item(final Player player, final ItemStack item_stack, final int amount) {
+		if (player.getGameMode() == GameMode.CREATIVE) { // don't damage the tool if the player is in creative
+			return;
+		} 
+
 		if (amount <= 0) {
 			return;
 		}
@@ -66,8 +67,9 @@ public class ItemUtil {
 		if (handle == null) {
 			return;
 		}
-
-		handle.hurtAndBreak(amount, randomSource, player_handle(player), () -> {});
+		RandomSource random = Nms.world_handle(player.getWorld()).getRandom();
+		
+		handle.hurtAndBreak(amount, random, player_handle(player), () -> { player.broadcastSlotBreak(EquipmentSlot.HAND); item_stack.subtract(); });
 	}
 
 	public static String name_of(final ItemStack item) {


### PR DESCRIPTION
Two changes added with 1.20.5/6:
- `max_damage` allows to set the maximum durability of an item. Already existing items should keep their durability. Vanilla Mending and repairing with an anvil or a grindstone works, but not merging 2 items in a crafting table.
- `item_name` set the default name of the item, so custom ones can be renamed without losing their default name when resetting it.