### PR TITLE
Fix: Player kick when removing an item from a item frame

### DIFF
--- a/vane-core/src/main/java/org/oddlama/vane/core/enchantments/CustomEnchantmentFixer.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/enchantments/CustomEnchantmentFixer.java
@@ -112,7 +112,8 @@ public class CustomEnchantmentFixer extends Listener<Core> {
         public void onPacketSending(PacketEvent event) {
             if (event.getPacket().getHandle() instanceof ClientboundSetEntityDataPacket edp) {
                 var newlist = edp.packedItems().stream().map(x -> {
-                    if (x.value() instanceof net.minecraft.world.item.ItemStack itemStack) {
+                    if (x.value() instanceof net.minecraft.world.item.ItemStack itemStack && !itemStack.isEmpty()) {
+
                         var bukkititem = CustomEnchantmentFixer.removeVaneEnchants(itemStack.asBukkitCopy());
                         var newitem = Nms.item_handle(bukkititem);
                         return new DataValue<net.minecraft.world.item.ItemStack>(x.id(),


### PR DESCRIPTION
A minor bug occurs when removing an item from an item frame, the player is kicked from the server.