### PR TITLE
fix: wrong version in trifles/lang-fr-fr.yml

### DIFF
--- a/vane-trifles/src/main/resources/lang-fr-fr.yml
+++ b/vane-trifles/src/main/resources/lang-fr-fr.yml
@@ -12,7 +12,7 @@
 
 # DO NOT CHANGE! The version of this language file. Used to determine
 # if the file needs to be updated.
-version: 5
+version: 4
 # The corresponding language code used in resource packs. Used for
 # resource pack generation. Typically, this is a combination of the
 # language code (ISO 639) and the country code (ISO 3166).


### PR DESCRIPTION
Fixes issue similar to #114 (see my comment here). All `trifles` lang files are in version `4`, this one was updated to version `5`, it makes the server crash