### PR TITLE
Use modules' fishing loot tables to randomly override fished items

### DIFF
--- a/vane-core/src/main/java/org/oddlama/vane/core/LootTable.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/LootTable.java
@@ -1,6 +1,7 @@
 package org.oddlama.vane.core;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,6 +35,12 @@ public class LootTable {
         return possible_loot;
     }
 
+    public List<LootTableEntry> flat_copy() {
+        List<LootTableEntry> list = new ArrayList<>();
+        possible_loot.values().forEach(list::addAll);
+        return list;
+    }
+
     public void generate_loot(final List<ItemStack> output, final Random random) {
         for (final var set : possible_loot.values()) {
             for (final var loot : set) {
@@ -48,15 +55,15 @@ public class LootTable {
         double total_chance = 0;
         final double threshold = random.nextDouble();
         final List<ItemStack> result_container = new ArrayList<>(1);
-        for (final var set : possible_loot.values()) {
-            for (final var loot : set) {
-                total_chance += loot.chance;
-                if (total_chance > threshold) {
-                    loot.add_sample(result_container, random);
-                }
-                if (!result_container.isEmpty()) {
-                    return result_container.get(0);
-                }
+        final var loot_list = flat_copy();
+        Collections.shuffle(loot_list, random);
+        for (final var loot : loot_list) {
+            total_chance += loot.chance;
+            if (total_chance > threshold) {
+                loot.add_sample(result_container, random);
+            }
+            if (!result_container.isEmpty()) {
+                return result_container.get(0);
             }
         }
         return null;

--- a/vane-core/src/main/java/org/oddlama/vane/core/LootTable.java
+++ b/vane-core/src/main/java/org/oddlama/vane/core/LootTable.java
@@ -1,5 +1,6 @@
 package org.oddlama.vane.core;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +42,24 @@ public class LootTable {
                 }
             }
         }
+    }
+
+    public ItemStack generate_override(final Random random) {
+        double total_chance = 0;
+        final double threshold = random.nextDouble();
+        final List<ItemStack> result_container = new ArrayList<>(1);
+        for (final var set : possible_loot.values()) {
+            for (final var loot : set) {
+                total_chance += loot.chance;
+                if (total_chance > threshold) {
+                    loot.add_sample(result_container, random);
+                }
+                if (!result_container.isEmpty()) {
+                    return result_container.get(0);
+                }
+            }
+        }
+        return null;
     }
 
     public static class LootTableEntry {


### PR DESCRIPTION
Add fishing event handler to the base `Module` class that rerolls one of the three fish loot categories (independently from the result got from the original vanilla roll, so skewing the effective probabilities) with weights that should emulate vanilla behavior (taking into account the player's Luck effect, Luck Of The Sea enchantment, and whether the fishing bobber is currently in open water) and randomly selects an item from the module's corresponding loot table proportional to its chance to replace the original fished item or preserves the original item with a chance of $`1.0 - \sum\text{of chances in the module's selected loot table}`$.

Fixes https://github.com/oddlama/vane/issues/292