### PR TITLE
vane-enchantments: Fix french translation version

### DIFF
--- a/vane-enchantments/src/main/resources/lang-fr-fr.yml
+++ b/vane-enchantments/src/main/resources/lang-fr-fr.yml
@@ -12,7 +12,7 @@
 
 # DO NOT CHANGE! The version of this language file. Used to determine
 # if the file needs to be updated.
-version: 5
+version: 4
 # The corresponding language code used in resource packs. Used for
 # resource pack generation. Typically, this is a combination of the
 # language code (ISO 639) and the country code (ISO 3166).


### PR DESCRIPTION
This plugin is currently at version 4, having version 5 prevents it from loading:
```
[vane-enchantments]: lang-fr-fr.yml: expected version 4, but got 5
[vane-enchantments]: This language file is for a future version of vane-enchantments.
[vane-enchantments]: Please use the correct file for this version, or use an officially
[vane-enchantments]: supported language file.
[vane-enchantments]: Invalid localization file. Shutting down.
```