### PR TITLE
fix: Issue #314

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-	`java-library`
-	id("io.papermc.paperweight.userdev") version "2.0.0-beta.16"
+//	`java-library`
+	id("io.papermc.paperweight.userdev") version "2.0.0-beta.18"
 	id("xyz.jpenilla.run-paper") version "2.3.1" // Adds runServer and runMojangMappedServer tasks for testing
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/StorageGroup.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/StorageGroup.java
@@ -32,7 +32,7 @@ import org.oddlama.vane.trifles.items.storage.Pouch;
 
 public class StorageGroup extends Listener<Trifles> {
 
-    private Map<Inventory, Pair<UUID, ItemStack>> open_block_state_inventories = Collections.synchronizedMap(
+    public Map<Inventory, Pair<UUID, ItemStack>> open_block_state_inventories = Collections.synchronizedMap(
         new HashMap<Inventory, Pair<UUID, ItemStack>>()
     );
 
@@ -41,6 +41,10 @@ public class StorageGroup extends Listener<Trifles> {
 
     public StorageGroup(Context<Trifles> context) {
         super(context.group("storage", "Extensions to storage related stuff will be grouped under here."));
+    }
+
+    public Map<Inventory, Pair<UUID, ItemStack>> get_open_block_state_inventories (){
+        return open_block_state_inventories;
     }
 
     @SuppressWarnings("deprecation")


### PR DESCRIPTION
Opened pouches have a tooltip saying that they are opened.
You can't move opened pouches in your inventory.

Refs: #314 