### PR TITLE
Grappling hook wall activation + improvements

### DIFF
--- a/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/GrapplingHook.java
+++ b/vane-enchantments/src/main/java/org/oddlama/vane/enchantments/enchantments/GrapplingHook.java
@@ -111,7 +111,7 @@ public class GrapplingHook extends CustomEnchantment<Enchantments> {
 
         // If the hook is below the player, set the Y component to 0.0 and only add the constant offset.
         // This prevents the player from just sliding against the ground when the hook is below them.
-        if (event.getPlayer().getY() - event.getHook().getY() > 0) {
+        if (player.getY() - event.getHook().getY() > 0) {
             adjusted_vector.setY(0.0).add(CONSTANT_OFFSET);
         }
 


### PR DESCRIPTION
- Remove unnecessary `FAILED_ATTEMPT` code. This state only triggers when you fail to catch a fish by timing the catch incorrectly (I think) and shouldn't be activating the grappling hook.
- Change `REEL_IN` state code to check for collisions so we can check if the hook is colliding with a wall and thus activate the grappling hook from walls instead of just the ground.
- Adjust vertical velocity if the hook is below the player. Before if the hook was below the player and they activated the grappling hook, they would just slide across the ground. Now if the hook is below the player, it will set the vertical velocity to 0, and then add the `CONSTANT_OFFSET` vector to ensure you get a little height bump. If the hook is above the player, behavior is unchanged.