### PR TITLE
New finditem command visualizations, now with packets!

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ configure(subprojects.filter {
 
 // All Projects with jar shadow
 configure(subprojects.filter {
-	listOf("vane-regions", "vane-core", "vane-portals", "vane-regions").contains(it.name)
+	listOf("vane-regions", "vane-core", "vane-portals", "vane-regions", "vane-trifles").contains(it.name)
 }) {
 	tasks.register<Copy>("copyJar") {
 		evaluationDependsOn(project.path)
@@ -77,7 +77,7 @@ configure(subprojects.filter {
 
 // All Projects without jar shadow
 configure(subprojects.filter {
-	listOf("vane-admin", "vane-bedtime", "vane-enchantments", "vane-permissions", "vane-trifles").contains(it.name)
+	listOf("vane-admin", "vane-bedtime", "vane-enchantments", "vane-permissions").contains(it.name)
 }) {
 	tasks.register<Copy>("copyJar") {
 		from(tasks.jar)

--- a/vane-trifles/build.gradle.kts
+++ b/vane-trifles/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+	id("io.github.goooler.shadow") version "8.1.8"
+}
+
+repositories {
+	maven("https://repo.codemc.io/repository/maven-releases/")
+	maven("https://repo.codemc.io/repository/maven-snapshots/")
+}
+
+dependencies {
+	compileOnly("com.github.retrooper:packetevents-spigot:2.9.4")
+	compileOnly(group = "org.json", name = "json", version = "20250107")
+}
+
+tasks {
+	shadowJar {
+		configurations = listOf()
+		relocate("org.json", "org.oddlama.vane.external.json")
+	}
+}

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
@@ -41,6 +41,9 @@ import org.oddlama.vane.util.StorageUtil;
 
 import java.util.Objects;
 
+import static org.oddlama.vane.trifles.ItemFinder.FOUND_TASK_ID;
+import static org.oddlama.vane.trifles.ItemFinder.IS_ENTITY_FOUND;
+
 public class ItemFinder extends Listener<Trifles> {
 
     public static final NamespacedKey IS_ENTITY_FOUND = StorageUtil.namespaced_key(
@@ -359,6 +362,12 @@ class UnsetGlowingTask implements Runnable {
     public void run() {
         if (entity.isValid()) {
             entity.setGlowing(false);
+            if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
+                entity.getPersistentDataContainer().remove(IS_ENTITY_FOUND);
+            }
+            if (entity.getPersistentDataContainer().has(FOUND_TASK_ID)) {
+                entity.getPersistentDataContainer().remove(FOUND_TASK_ID);
+            }
         }
     }
 }

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
@@ -1,35 +1,70 @@
 package org.oddlama.vane.trifles;
 
+import io.papermc.paper.block.TileStateInventoryHolder;
+import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.entity.BlockDisplay;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.world.EntitiesLoadEvent;
+import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.NotNull;
+import org.joml.AxisAngle4f;
+import org.joml.Vector3f;
 import org.oddlama.vane.annotation.config.ConfigBoolean;
 import org.oddlama.vane.annotation.config.ConfigInt;
 import org.oddlama.vane.core.Listener;
 import org.oddlama.vane.core.module.Context;
 import org.oddlama.vane.util.StorageUtil;
 
+import java.util.Objects;
+
 public class ItemFinder extends Listener<Trifles> {
 
-    public static final NamespacedKey LAST_FIND_TIME = StorageUtil.namespaced_key(
-        "vane_trifles",
-        "last_item_find_time"
+    public static final NamespacedKey IS_ENTITY_FOUND = StorageUtil.namespaced_key(
+            "vane_trifles",
+            "is_entity_found"
     );
+
+    public static final NamespacedKey FOUND_TASK_ID = StorageUtil.namespaced_key(
+            "vane_trifles",
+            "found_task_id"
+    );
+
+    private final static long ACTIVE_GLOW_TIME = 20 * 10L; // 10 seconds
+    private final static float CONTAINER_DEFAULT_SCALE = 0.96f;
+    private final static float CONTAINER_DEFAULT_TRANSLATION = 0.02f;
+    private final static int X_COMPONENT = 0;
+    private final static int Z_COMPONENT = 2;
+    private final static float EPSILON = 0.5f;
+    private final static float CHEST_DEFAULT_SCALE = 0.8f;
+    private final static float CHEST_DEFAULT_TRANSLATION = 0.1f;
+    private final static float CHEST_Y_TRANSLATION = 0.05f;
+    private final static float DOUBLE_CHEST_SCALE = 1.8f;
+    private final static float DOUBLE_CHEST_TRANSLATION_OFFSET = -0.9f;
+    private final static AxisAngle4f BLANK_ROTATION_DATA = new AxisAngle4f();
 
     @ConfigInt(
         def = 2,
@@ -99,11 +134,148 @@ public class ItemFinder extends Listener<Trifles> {
         return block.getState() instanceof Container;
     }
 
-    private void indicate_match_at(@NotNull Player player, @NotNull Location location) {
-        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.4, 0.0, 0.0, 0.0);
-        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.0, 0.4, 0.0, 0.0);
-        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.0, 0.0, 0.4, 0.0);
-        player.spawnParticle(Particle.CAMPFIRE_SIGNAL_SMOKE, location, 70, 0.2, 0.2, 0.2, 0.0);
+    // All the containers besides chests
+    private void indicate_container_match_at(@NotNull Player player, @NotNull Location location, @NotNull BlockData data) {
+        remove_existing_glow_entities(location);
+        var display = player.getWorld().spawn(location, BlockDisplay.class, entity -> {
+            entity.setBlock(data);
+            entity.setTransformation(
+                new Transformation(
+                        new Vector3f(CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION),
+                        BLANK_ROTATION_DATA,
+                        new Vector3f(CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE),
+                        BLANK_ROTATION_DATA
+                )
+            );
+            entity.setGlowing(true);
+            entity.setGlowColorOverride(Color.WHITE);
+            entity.setPersistent(false); // Marked non-persistent so it will be removed after server restart in case it is not killed
+            entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
+        });
+
+        get_module().getServer().getScheduler().runTaskLater(get_module(), new KillEntityTask(display), ACTIVE_GLOW_TIME);
+    }
+
+    // Special function for chests
+    private void indicate_chest_match_at(@NotNull Player player, @NotNull Container container) {
+        remove_existing_glow_entities(container.getLocation());
+        var scale_vector = new Vector3f(CHEST_DEFAULT_SCALE, CHEST_DEFAULT_SCALE, CHEST_DEFAULT_SCALE); // Defaults for single chest
+        var translation_vector = new Vector3f(CHEST_DEFAULT_TRANSLATION, CHEST_Y_TRANSLATION, CHEST_DEFAULT_TRANSLATION); // Defaults for single chest
+
+        // Scale calculations for a double chest
+        if (container.getInventory() instanceof DoubleChestInventory) {
+            var left_side = ((DoubleChestInventory) container.getInventory()).getLeftSide();
+            var right_side = ((DoubleChestInventory) container.getInventory()).getRightSide();
+            if (Objects.equals(right_side.getLocation(), container.getLocation())) {
+                return; // Only do work on left sides to avoid spawning 2 entities
+            }
+            var left_x = left_side.getLocation().getX();
+            var left_z = left_side.getLocation().getZ();
+            var right_x = right_side.getLocation().getX();
+            var right_z = right_side.getLocation().getZ();
+
+            if (right_x - left_x > EPSILON) { // facing south
+                scale_vector.setComponent(X_COMPONENT, DOUBLE_CHEST_SCALE);
+            } else if (left_x - right_x > EPSILON) { // facing north
+                scale_vector.setComponent(X_COMPONENT, DOUBLE_CHEST_SCALE);
+                translation_vector.setComponent(0, DOUBLE_CHEST_TRANSLATION_OFFSET);
+            } else if (right_z - left_z > EPSILON) { // facing east
+                scale_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_SCALE);
+            } else if (left_z - right_z > EPSILON) { // facing west
+                scale_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_SCALE);
+                translation_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_TRANSLATION_OFFSET);
+            }
+        }
+        var display = player.getWorld().spawn(container.getLocation(), BlockDisplay.class, entity -> {
+            entity.setBlock(Material.BLACK_CONCRETE.createBlockData());
+            entity.setTransformation(
+                    new Transformation(
+                            translation_vector,
+                            BLANK_ROTATION_DATA,
+                            scale_vector,
+                            BLANK_ROTATION_DATA
+                    )
+            );
+            entity.setGlowing(true);
+            entity.setGlowColorOverride(Color.WHITE);
+            entity.setPersistent(false); // Marked non-persistent so it will be removed after server restart in case it is not killed
+            entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
+        });
+        get_module().getServer().getScheduler().runTaskLater(get_module(), new KillEntityTask(display), ACTIVE_GLOW_TIME);
+    }
+
+    // Remove the glow when the player opens the glowing block inventory
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void on_interact_event(PlayerInteractEvent event) {
+        if (event.getClickedBlock() == null) {
+            return;
+        }
+        if (!(event.getClickedBlock().getState() instanceof TileStateInventoryHolder)) {
+            return;
+        }
+        var checked_location = event.getClickedBlock().getLocation();
+        // Stupid double chest check shenanigans
+        if (((TileStateInventoryHolder) event.getClickedBlock().getState()).getInventory() instanceof DoubleChestInventory) {
+            checked_location = ((DoubleChestInventory) ((TileStateInventoryHolder) event.getClickedBlock().getState()).getInventory()).getLeftSide().getLocation();
+        }
+        if (checked_location != null) {
+            remove_existing_glow_entities(checked_location);
+        }
+    }
+    // Remove the glow when the player opens the glowing entity inventory
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void on_interact_event(PlayerInteractEntityEvent event) {
+        if (event.getRightClicked().getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
+            event.getRightClicked().setGlowing(false);
+        }
+    }
+
+    // Entities like chest minecarts
+    private void indicate_entity_match_at(@NotNull Player player, @NotNull Entity entity) {
+        // Make sure we don't cut the glow time short if the command is run twice in a row
+        if (entity.getPersistentDataContainer().has(FOUND_TASK_ID)) {
+            var task_id = entity.getPersistentDataContainer().get(FOUND_TASK_ID, PersistentDataType.INTEGER);
+            if (task_id != null) {
+                get_module().getServer().getScheduler().cancelTask(task_id);
+            }
+        }
+        entity.setGlowing(true);
+        entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
+
+        var task = get_module().getServer().getScheduler().runTaskLater(get_module(), new UnsetGlowingTask(entity), ACTIVE_GLOW_TIME);
+        entity.getPersistentDataContainer().set(FOUND_TASK_ID, PersistentDataType.INTEGER, task.getTaskId());
+    }
+
+    // Handle bugged glowing entities (minecart, boats, etc) on load
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void on_load_entities(EntitiesLoadEvent event) {
+        for (var entity : event.getEntities()) {
+            if (entity.isGlowing()) {
+                if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN)) {
+                    entity.setGlowing(false);
+                    entity.getPersistentDataContainer().remove(IS_ENTITY_FOUND);
+                }
+                if (entity.getPersistentDataContainer().has(FOUND_TASK_ID, PersistentDataType.BOOLEAN)) {
+                    entity.setGlowing(false);
+                    entity.getPersistentDataContainer().remove(FOUND_TASK_ID);
+                }
+            }
+        }
+    }
+
+    // Living entities
+    private void indicate_living_entity_match_at(@NotNull Player player, @NotNull LivingEntity entity) {
+        entity.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, (int) ACTIVE_GLOW_TIME, 0, true, false, false));
+    }
+
+    private void remove_existing_glow_entities(Location location) {
+        // Make sure we aren't creating multiple entities on top of each other with multiple commands ran
+        var entities = location.getNearbyEntities(1f, 1f, 1f);
+        for (Entity entity : entities) {
+            if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
+                entity.remove();
+            }
+        }
     }
 
     public boolean find_item(@NotNull final Player player, @NotNull final Material material) {
@@ -120,7 +292,11 @@ public class ItemFinder extends Listener<Trifles> {
                 for (final var tile_entity : chunk.getTileEntities(this::is_container, false)) {
                     if (tile_entity instanceof Container container) {
                         if (container.getInventory().contains(material)) {
-                            indicate_match_at(player, container.getLocation().add(0.5, 0.5, 0.5));
+                            if (container.getType() == Material.CHEST) {
+                                indicate_chest_match_at(player, container);
+                            } else {
+                                indicate_container_match_at(player, container.getLocation(), container.getBlockData());
+                            }
                             any_found = true;
                         }
                     }
@@ -134,7 +310,11 @@ public class ItemFinder extends Listener<Trifles> {
 
                         if (entity instanceof InventoryHolder holder) {
                             if (holder.getInventory().contains(material)) {
-                                indicate_match_at(player, entity.getLocation());
+                                if (entity instanceof LivingEntity living_entity) {
+                                    indicate_living_entity_match_at(player, living_entity);
+                                } else {
+                                    indicate_entity_match_at(player, entity);
+                                }
                                 any_found = true;
                             }
                         }
@@ -150,5 +330,35 @@ public class ItemFinder extends Listener<Trifles> {
         }
 
         return any_found;
+    }
+}
+
+class KillEntityTask implements Runnable {
+    private final BlockDisplay display;
+
+    public KillEntityTask(BlockDisplay display) {
+        this.display = display;
+    }
+
+    @Override
+    public void run() {
+        if (display.isValid()) {
+            display.remove();
+        }
+    }
+}
+
+class UnsetGlowingTask implements Runnable {
+    private final Entity entity;
+
+    public UnsetGlowingTask(Entity entity) {
+        this.entity = entity;
+    }
+
+    @Override
+    public void run() {
+        if (entity.isValid()) {
+            entity.setGlowing(false);
+        }
     }
 }

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinder.java
@@ -1,74 +1,32 @@
 package org.oddlama.vane.trifles;
 
-import io.papermc.paper.block.TileStateInventoryHolder;
-import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
+import org.bukkit.Particle;
 import org.bukkit.Sound;
 import org.bukkit.SoundCategory;
 import org.bukkit.block.Block;
 import org.bukkit.block.Container;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.entity.BlockDisplay;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.event.world.EntitiesLoadEvent;
-import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.InventoryHolder;
 import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
-import org.bukkit.persistence.PersistentDataType;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.potion.PotionEffectType;
-import org.bukkit.util.Transformation;
 import org.jetbrains.annotations.NotNull;
-import org.joml.AxisAngle4f;
-import org.joml.Vector3f;
 import org.oddlama.vane.annotation.config.ConfigBoolean;
 import org.oddlama.vane.annotation.config.ConfigInt;
 import org.oddlama.vane.core.Listener;
 import org.oddlama.vane.core.module.Context;
-import org.oddlama.vane.util.StorageUtil;
 
-import java.util.Objects;
-
-import static org.oddlama.vane.trifles.ItemFinder.FOUND_TASK_ID;
-import static org.oddlama.vane.trifles.ItemFinder.IS_ENTITY_FOUND;
+import static org.oddlama.vane.trifles.ItemFinderPacketUtils.indicate_chest_match;
+import static org.oddlama.vane.trifles.ItemFinderPacketUtils.indicate_container_match;
+import static org.oddlama.vane.trifles.ItemFinderPacketUtils.indicate_entity_match;
 
 public class ItemFinder extends Listener<Trifles> {
-
-    public static final NamespacedKey IS_ENTITY_FOUND = StorageUtil.namespaced_key(
-            "vane_trifles",
-            "is_entity_found"
-    );
-
-    public static final NamespacedKey FOUND_TASK_ID = StorageUtil.namespaced_key(
-            "vane_trifles",
-            "found_task_id"
-    );
-
-    private final static long ACTIVE_GLOW_TIME = 20 * 10L; // 10 seconds
-    private final static float CONTAINER_DEFAULT_SCALE = 0.96f;
-    private final static float CONTAINER_DEFAULT_TRANSLATION = 0.02f;
-    private final static int X_COMPONENT = 0;
-    private final static int Z_COMPONENT = 2;
-    private final static float EPSILON = 0.5f;
-    private final static float CHEST_DEFAULT_SCALE = 0.8f;
-    private final static float CHEST_DEFAULT_TRANSLATION = 0.1f;
-    private final static float CHEST_Y_TRANSLATION = 0.05f;
-    private final static float DOUBLE_CHEST_SCALE = 1.8f;
-    private final static float DOUBLE_CHEST_TRANSLATION_OFFSET = -0.9f;
-    private final static AxisAngle4f BLANK_ROTATION_DATA = new AxisAngle4f();
-
     @ConfigInt(
         def = 2,
         min = 1,
@@ -85,6 +43,8 @@ public class ItemFinder extends Listener<Trifles> {
         desc = "Only allow players to use the shift+rightclick shortcut when they have the shortcut permission `vane.trifles.use_item_find_shortcut`."
     )
     public boolean config_require_permission;
+
+    private static final int FALLBACK_TASK_INTERVAL = 15;
 
     // This permission allows players to use the shift+rightclick.
     public final Permission use_item_find_shortcut_permission;
@@ -137,148 +97,11 @@ public class ItemFinder extends Listener<Trifles> {
         return block.getState() instanceof Container;
     }
 
-    // All the containers besides chests
-    private void indicate_container_match_at(@NotNull Player player, @NotNull Location location, @NotNull BlockData data) {
-        remove_existing_glow_entities(location);
-        var display = player.getWorld().spawn(location, BlockDisplay.class, entity -> {
-            entity.setBlock(data);
-            entity.setTransformation(
-                new Transformation(
-                        new Vector3f(CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION),
-                        BLANK_ROTATION_DATA,
-                        new Vector3f(CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE),
-                        BLANK_ROTATION_DATA
-                )
-            );
-            entity.setGlowing(true);
-            entity.setGlowColorOverride(Color.WHITE);
-            entity.setPersistent(false); // Marked non-persistent so it will be removed after server restart in case it is not killed
-            entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
-        });
-
-        get_module().getServer().getScheduler().runTaskLater(get_module(), new KillEntityTask(display), ACTIVE_GLOW_TIME);
-    }
-
-    // Special function for chests
-    private void indicate_chest_match_at(@NotNull Player player, @NotNull Container container) {
-        remove_existing_glow_entities(container.getLocation());
-        var scale_vector = new Vector3f(CHEST_DEFAULT_SCALE, CHEST_DEFAULT_SCALE, CHEST_DEFAULT_SCALE); // Defaults for single chest
-        var translation_vector = new Vector3f(CHEST_DEFAULT_TRANSLATION, CHEST_Y_TRANSLATION, CHEST_DEFAULT_TRANSLATION); // Defaults for single chest
-
-        // Scale calculations for a double chest
-        if (container.getInventory() instanceof DoubleChestInventory) {
-            var left_side = ((DoubleChestInventory) container.getInventory()).getLeftSide();
-            var right_side = ((DoubleChestInventory) container.getInventory()).getRightSide();
-            if (Objects.equals(right_side.getLocation(), container.getLocation())) {
-                return; // Only do work on left sides to avoid spawning 2 entities
-            }
-            var left_x = left_side.getLocation().getX();
-            var left_z = left_side.getLocation().getZ();
-            var right_x = right_side.getLocation().getX();
-            var right_z = right_side.getLocation().getZ();
-
-            if (right_x - left_x > EPSILON) { // facing south
-                scale_vector.setComponent(X_COMPONENT, DOUBLE_CHEST_SCALE);
-            } else if (left_x - right_x > EPSILON) { // facing north
-                scale_vector.setComponent(X_COMPONENT, DOUBLE_CHEST_SCALE);
-                translation_vector.setComponent(0, DOUBLE_CHEST_TRANSLATION_OFFSET);
-            } else if (right_z - left_z > EPSILON) { // facing east
-                scale_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_SCALE);
-            } else if (left_z - right_z > EPSILON) { // facing west
-                scale_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_SCALE);
-                translation_vector.setComponent(Z_COMPONENT, DOUBLE_CHEST_TRANSLATION_OFFSET);
-            }
-        }
-        var display = player.getWorld().spawn(container.getLocation(), BlockDisplay.class, entity -> {
-            entity.setBlock(Material.BLACK_CONCRETE.createBlockData());
-            entity.setTransformation(
-                    new Transformation(
-                            translation_vector,
-                            BLANK_ROTATION_DATA,
-                            scale_vector,
-                            BLANK_ROTATION_DATA
-                    )
-            );
-            entity.setGlowing(true);
-            entity.setGlowColorOverride(Color.WHITE);
-            entity.setPersistent(false); // Marked non-persistent so it will be removed after server restart in case it is not killed
-            entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
-        });
-        get_module().getServer().getScheduler().runTaskLater(get_module(), new KillEntityTask(display), ACTIVE_GLOW_TIME);
-    }
-
-    // Remove the glow when the player opens the glowing block inventory
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void on_interact_event(PlayerInteractEvent event) {
-        if (event.getClickedBlock() == null) {
-            return;
-        }
-        if (!(event.getClickedBlock().getState() instanceof TileStateInventoryHolder)) {
-            return;
-        }
-        var checked_location = event.getClickedBlock().getLocation();
-        // Stupid double chest check shenanigans
-        if (((TileStateInventoryHolder) event.getClickedBlock().getState()).getInventory() instanceof DoubleChestInventory) {
-            checked_location = ((DoubleChestInventory) ((TileStateInventoryHolder) event.getClickedBlock().getState()).getInventory()).getLeftSide().getLocation();
-        }
-        if (checked_location != null) {
-            remove_existing_glow_entities(checked_location);
-        }
-    }
-    // Remove the glow when the player opens the glowing entity inventory
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void on_interact_event(PlayerInteractEntityEvent event) {
-        if (event.getRightClicked().getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
-            event.getRightClicked().setGlowing(false);
-        }
-    }
-
-    // Entities like chest minecarts
-    private void indicate_entity_match_at(@NotNull Player player, @NotNull Entity entity) {
-        // Make sure we don't cut the glow time short if the command is run twice in a row
-        if (entity.getPersistentDataContainer().has(FOUND_TASK_ID)) {
-            var task_id = entity.getPersistentDataContainer().get(FOUND_TASK_ID, PersistentDataType.INTEGER);
-            if (task_id != null) {
-                get_module().getServer().getScheduler().cancelTask(task_id);
-            }
-        }
-        entity.setGlowing(true);
-        entity.getPersistentDataContainer().set(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN, true);
-
-        var task = get_module().getServer().getScheduler().runTaskLater(get_module(), new UnsetGlowingTask(entity), ACTIVE_GLOW_TIME);
-        entity.getPersistentDataContainer().set(FOUND_TASK_ID, PersistentDataType.INTEGER, task.getTaskId());
-    }
-
-    // Handle bugged glowing entities (minecart, boats, etc) on load
-    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
-    public void on_load_entities(EntitiesLoadEvent event) {
-        for (var entity : event.getEntities()) {
-            if (entity.isGlowing()) {
-                if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND, PersistentDataType.BOOLEAN)) {
-                    entity.setGlowing(false);
-                    entity.getPersistentDataContainer().remove(IS_ENTITY_FOUND);
-                }
-                if (entity.getPersistentDataContainer().has(FOUND_TASK_ID, PersistentDataType.BOOLEAN)) {
-                    entity.setGlowing(false);
-                    entity.getPersistentDataContainer().remove(FOUND_TASK_ID);
-                }
-            }
-        }
-    }
-
-    // Living entities
-    private void indicate_living_entity_match_at(@NotNull Player player, @NotNull LivingEntity entity) {
-        entity.addPotionEffect(new PotionEffect(PotionEffectType.GLOWING, (int) ACTIVE_GLOW_TIME, 0, true, false, false));
-    }
-
-    private void remove_existing_glow_entities(Location location) {
-        // Make sure we aren't creating multiple entities on top of each other with multiple commands ran
-        var entities = location.getNearbyEntities(1f, 1f, 1f);
-        for (Entity entity : entities) {
-            if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
-                entity.remove();
-            }
-        }
+    private void fallback_indicate_match(@NotNull Player player, @NotNull Location location) {
+        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.4, 0.0, 0.0, 0.0);
+        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.0, 0.4, 0.0, 0.0);
+        player.spawnParticle(Particle.DRIPPING_OBSIDIAN_TEAR, location, 130, 0.0, 0.0, 0.4, 0.0);
+        player.spawnParticle(Particle.CAMPFIRE_SIGNAL_SMOKE, location, 70, 0.2, 0.2, 0.2, 0.0);
     }
 
     public boolean find_item(@NotNull final Player player, @NotNull final Material material) {
@@ -286,6 +109,7 @@ public class ItemFinder extends Listener<Trifles> {
         boolean any_found = false;
         final var world = player.getWorld();
         final var origin_chunk = player.getChunk();
+        final var packet_events_enabled = get_module().packet_events_enabled;
         for (int cx = origin_chunk.getX() - config_radius; cx <= origin_chunk.getX() + config_radius; ++cx) {
             for (int cz = origin_chunk.getZ() - config_radius; cz <= origin_chunk.getZ() + config_radius; ++cz) {
                 if (!world.isChunkLoaded(cx, cz)) {
@@ -296,9 +120,17 @@ public class ItemFinder extends Listener<Trifles> {
                     if (tile_entity instanceof Container container) {
                         if (container.getInventory().contains(material)) {
                             if (container.getType() == Material.CHEST) {
-                                indicate_chest_match_at(player, container);
+                                if (packet_events_enabled) {
+                                    indicate_chest_match(get_module(), player, container);
+                                } else {
+                                    fallback_indicate_match(player, container.getLocation().add(0.5, 0.5, 0.5));
+                                }
                             } else {
-                                indicate_container_match_at(player, container.getLocation(), container.getBlockData());
+                                if (packet_events_enabled) {
+                                    indicate_container_match(get_module(), player, container);
+                                } else {
+                                    fallback_indicate_match(player, container.getLocation().add(0.5, 0.5, 0.5));
+                                }
                             }
                             any_found = true;
                         }
@@ -313,10 +145,10 @@ public class ItemFinder extends Listener<Trifles> {
 
                         if (entity instanceof InventoryHolder holder) {
                             if (holder.getInventory().contains(material)) {
-                                if (entity instanceof LivingEntity living_entity) {
-                                    indicate_living_entity_match_at(player, living_entity);
+                                if (packet_events_enabled) {
+                                    indicate_entity_match(get_module(), player, entity);
                                 } else {
-                                    indicate_entity_match_at(player, entity);
+                                    fallback_indicate_match(player, entity.getLocation());
                                 }
                                 any_found = true;
                             }
@@ -333,41 +165,5 @@ public class ItemFinder extends Listener<Trifles> {
         }
 
         return any_found;
-    }
-}
-
-class KillEntityTask implements Runnable {
-    private final BlockDisplay display;
-
-    public KillEntityTask(BlockDisplay display) {
-        this.display = display;
-    }
-
-    @Override
-    public void run() {
-        if (display.isValid()) {
-            display.remove();
-        }
-    }
-}
-
-class UnsetGlowingTask implements Runnable {
-    private final Entity entity;
-
-    public UnsetGlowingTask(Entity entity) {
-        this.entity = entity;
-    }
-
-    @Override
-    public void run() {
-        if (entity.isValid()) {
-            entity.setGlowing(false);
-            if (entity.getPersistentDataContainer().has(IS_ENTITY_FOUND)) {
-                entity.getPersistentDataContainer().remove(IS_ENTITY_FOUND);
-            }
-            if (entity.getPersistentDataContainer().has(FOUND_TASK_ID)) {
-                entity.getPersistentDataContainer().remove(FOUND_TASK_ID);
-            }
-        }
     }
 }

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinderPacketUtils.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/ItemFinderPacketUtils.java
@@ -1,0 +1,220 @@
+package org.oddlama.vane.trifles;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.attribute.Attributes;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityData;
+import com.github.retrooper.packetevents.protocol.entity.data.EntityDataTypes;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.util.Vector3f;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerDestroyEntities;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerEntityMetadata;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerUpdateAttributes;
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import io.github.retrooper.packetevents.util.SpigotReflectionUtil;
+import org.bukkit.block.Container;
+import org.bukkit.block.ShulkerBox;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.UUID;
+
+public class ItemFinderPacketUtils {
+    private final static long GLOW_DURATION = 20L * 8L; // 8 Seconds
+    private final static float CONTAINER_DEFAULT_SCALE = 0.95f;
+    private final static float CONTAINER_DEFAULT_TRANSLATION = (1 - CONTAINER_DEFAULT_SCALE) * 0.5f;
+    private final static float CHEST_DEFAULT_SCALE = 0.85f;
+
+    static void indicate_entity_match(@NotNull Trifles module, @NotNull Player player, @NotNull Entity entity) {
+        // Get base entity data
+        var base_entity_data = SpigotConversionUtil.getEntityMetadata(entity);
+
+        // Generate metadata with glowing turned on
+        var glowing_entity_data = new ArrayList<>(base_entity_data);
+        var glow_data = new EntityData<>(0, EntityDataTypes.BYTE, (byte) 0x40);
+        glowing_entity_data.add(glow_data);
+
+        // Create packet and set glowing metadata
+        var glowing_packet = new WrapperPlayServerEntityMetadata(
+                entity.getEntityId(),
+                glowing_entity_data
+        );
+
+        // Send packet
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, glowing_packet);
+
+        // Schedule repeating packet b/c if the player looks away from entities, they will stop glowing
+        var repeating_packet_task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                if (!player.isOnline()) {
+                    this.cancel();
+                }
+
+                PacketEvents.getAPI().getPlayerManager().sendPacket(player, glowing_packet);
+            }
+        }.runTaskTimer(module, 1, 1);
+
+        // Create non-glowing packet
+        var non_glowing_entity_data = new ArrayList<>(base_entity_data);
+        WrapperPlayServerEntityMetadata non_glowing_packet = new WrapperPlayServerEntityMetadata(
+                entity.getEntityId(),
+                non_glowing_entity_data
+        );
+
+        // Run task later to send packet to stop glowing
+        new ResetGlowingPacketTask(player, non_glowing_packet, repeating_packet_task).runTaskLater(module, GLOW_DURATION);
+    }
+
+    static void indicate_container_match(@NotNull Trifles module, @NotNull Player player, @NotNull Container container) {
+        int display_id = SpigotReflectionUtil.generateEntityId();
+        // Check for Shulkers so we can handle them differently
+        var entity_type = (container instanceof ShulkerBox) ? EntityTypes.SHULKER : EntityTypes.BLOCK_DISPLAY;
+        var display_packet = new WrapperPlayServerSpawnEntity(
+                display_id,
+                UUID.randomUUID(),
+                entity_type,
+                SpigotConversionUtil.fromBukkitLocation(container.getLocation()),
+                container.getLocation().getYaw(),
+                0,
+                null
+        );
+
+        // Metadata
+        var display_metadata = new ArrayList<EntityData<?>>();
+        display_metadata.add(new EntityData<>(0, EntityDataTypes.BYTE, (byte) (0x20 | 0x40)));
+        if (entity_type == EntityTypes.BLOCK_DISPLAY) {
+            display_metadata.add(new EntityData<>(11, EntityDataTypes.VECTOR3F, new Vector3f(CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION, CONTAINER_DEFAULT_TRANSLATION)));
+            display_metadata.add(new EntityData<>(12, EntityDataTypes.VECTOR3F, new Vector3f(CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE, CONTAINER_DEFAULT_SCALE)));
+            display_metadata.add(new EntityData<>(23, EntityDataTypes.BLOCK_STATE, SpigotConversionUtil.fromBukkitBlockData(container.getBlockData()).getGlobalId()));
+        }
+        var display_metadata_packet = new WrapperPlayServerEntityMetadata(
+                display_id,
+                display_metadata
+        );
+
+        // Send packets
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, display_packet);
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, display_metadata_packet);
+
+        // Shulker specific scale attribute packet
+        if (entity_type == EntityTypes.SHULKER) {
+            var scale_attribute = Attributes.SCALE;
+
+            // Create scale attribute modifier
+            var attribute_modifier = new WrapperPlayServerUpdateAttributes.PropertyModifier(
+                    UUID.randomUUID(),
+                    CONTAINER_DEFAULT_SCALE - 1,
+                    WrapperPlayServerUpdateAttributes.PropertyModifier.Operation.ADDITION
+            );
+            // Create scale attribute base property
+            var attribute_property = new WrapperPlayServerUpdateAttributes.Property(
+                    scale_attribute,
+                    1.0,
+                    Collections.singletonList(attribute_modifier)
+            );
+            // Create update attribute packet
+            var attribute_packet = new WrapperPlayServerUpdateAttributes(
+                    display_id,
+                    Collections.singletonList(attribute_property)
+            );
+
+            // Send packet
+            PacketEvents.getAPI().getPlayerManager().sendPacket(player, attribute_packet);
+        }
+
+        // Construct destroy entity packet
+        var destroy_entity_packet = new WrapperPlayServerDestroyEntities(display_id);
+
+        // Run task later to remove entity
+        new ResetGlowingPacketTask(player, destroy_entity_packet, null).runTaskLater(module, GLOW_DURATION);
+    }
+
+    // Special function for chests
+    static void indicate_chest_match(@NotNull Trifles module, @NotNull Player player, @NotNull Container container) {
+        int display_id = SpigotReflectionUtil.generateEntityId();
+        var display_packet = new WrapperPlayServerSpawnEntity(
+                display_id,
+                UUID.randomUUID(),
+                EntityTypes.SHULKER,
+                SpigotConversionUtil.fromBukkitLocation(container.getLocation()),
+                container.getLocation().getYaw(),
+                0,
+                null
+        );
+
+        // Metadata
+        var display_metadata = new ArrayList<EntityData<?>>();
+        display_metadata.add(new EntityData<>(0, EntityDataTypes.BYTE, (byte) (0x20 | 0x40)));
+        var display_metadata_packet = new WrapperPlayServerEntityMetadata(
+                display_id,
+                display_metadata
+        );
+
+        // Send packets
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, display_packet);
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, display_metadata_packet);
+
+        // Shulker specific scale attribute packet
+        var scale_attribute = Attributes.SCALE;
+
+        // Create scale attribute modifier
+        var attribute_modifier = new WrapperPlayServerUpdateAttributes.PropertyModifier(
+                UUID.randomUUID(),
+                CHEST_DEFAULT_SCALE - 1,
+                WrapperPlayServerUpdateAttributes.PropertyModifier.Operation.ADDITION
+        );
+        // Create scale attribute base property
+        var attribute_property = new WrapperPlayServerUpdateAttributes.Property(
+                scale_attribute,
+                1.0,
+                Collections.singletonList(attribute_modifier)
+        );
+        // Create update attribute packet
+        var attribute_packet = new WrapperPlayServerUpdateAttributes(
+                display_id,
+                Collections.singletonList(attribute_property)
+        );
+
+        // Send packet
+        PacketEvents.getAPI().getPlayerManager().sendPacket(player, attribute_packet);
+
+        // Construct destroy entity packet
+        var destroy_entity_packet = new WrapperPlayServerDestroyEntities(display_id);
+
+        // Run task later to remove entity
+        new ResetGlowingPacketTask(player, destroy_entity_packet, null).runTaskLater(module, GLOW_DURATION);
+    }
+
+    private static class ResetGlowingPacketTask extends BukkitRunnable {
+        private final Player player;
+        private final PacketWrapper<?> packet;
+        private final BukkitTask optional_repeating_packet_task;
+
+        public ResetGlowingPacketTask(@NotNull Player player, @NotNull PacketWrapper<?> packet, @Nullable BukkitTask optional_repeating_packet_task) {
+            this.player = player;
+            this.packet = packet;
+            this.optional_repeating_packet_task = optional_repeating_packet_task;
+        }
+
+        @Override
+        public void run() {
+            if (!player.isOnline()) {
+                this.cancel();
+            }
+
+            if (optional_repeating_packet_task != null && !optional_repeating_packet_task.isCancelled()) {
+                optional_repeating_packet_task.cancel();
+            }
+
+            PacketEvents.getAPI().getPlayerManager().sendPacket(player, packet);
+        }
+    }
+}

--- a/vane-trifles/src/main/java/org/oddlama/vane/trifles/Trifles.java
+++ b/vane-trifles/src/main/java/org/oddlama/vane/trifles/Trifles.java
@@ -1,10 +1,11 @@
 package org.oddlama.vane.trifles;
 
-import java.util.HashMap;
-import java.util.UUID;
 import org.oddlama.vane.annotation.VaneModule;
 import org.oddlama.vane.core.module.Module;
 import org.oddlama.vane.trifles.items.XpBottles;
+
+import java.util.HashMap;
+import java.util.UUID;
 
 @VaneModule(name = "trifles", bstats = 8644, config_version = 4, lang_version = 4, storage_version = 1)
 public class Trifles extends Module<Trifles> {
@@ -13,6 +14,7 @@ public class Trifles extends Module<Trifles> {
     public XpBottles xp_bottles;
     public ItemFinder item_finder;
     public StorageGroup storage_group;
+    public boolean packet_events_enabled;
 
     public Trifles() {
         final var fast_walking_group = new FastWalkingGroup(this);
@@ -43,5 +45,17 @@ public class Trifles extends Module<Trifles> {
         storage_group = new StorageGroup(this);
         new org.oddlama.vane.trifles.items.storage.Pouch(storage_group.get_context());
         new org.oddlama.vane.trifles.items.storage.Backpack(storage_group.get_context());
+    }
+
+    @Override
+    public void on_enable() {
+        get_module().schedule_next_tick(() -> {
+            var packet_events_plugin = get_module().getServer().getPluginManager().getPlugin("PacketEvents");
+
+            if (packet_events_plugin != null && packet_events_plugin.isEnabled()) {
+                packet_events_enabled = true;
+                get_module().log.info("Enabling PacketEvents integration");
+            }
+        });
     }
 }

--- a/vane-trifles/src/main/resources/paper-plugin.yml
+++ b/vane-trifles/src/main/resources/paper-plugin.yml
@@ -2,8 +2,7 @@ name: ${name}
 version: ${version}
 description: Trifles module for vane
 
-authors: 
-  - oddlama
+authors: [oddlama]
 website: 'https://github.com/oddlama/vane'
 
 main: org.oddlama.vane.trifles.Trifles
@@ -13,5 +12,8 @@ load: STARTUP
 dependencies:
   server:
     vane-core:
-      required: true
       load: BEFORE
+      required: true
+    packetevents:
+      load: BEFORE
+      required: false


### PR DESCRIPTION
Implements #306, still respects and uses all the same settings as the previous implementation
<img width="853" height="672" alt="image" src="https://github.com/user-attachments/assets/4baafb0c-7bf0-41a8-a1d0-a73a88935c8a" />
## Four Container Categories
### Chests
- A black concrete block display entity is spawned just smaller than the chest and given a glow effect.
- Double chests are accounted for and scaled properly (only the left side is processed to avoid spawning two entities for a double chest).
- These are set as non-persistent so if something goes wrong and the server crashes, they are automatically deleted.
- Otherwise the `KillEntityTask` is ran after 10 seconds to remove the glowing block display entity.
- The `vane_trifles:IS_ENTITY_FOUND` data tag is added and checked to prevent multiple display entities from existing at the same time for the same chest
### Block Entities
- These are all the other block entities that aren't chests (shulker boxes, dispensers, brewing stands, etc)
- Essentially work the same exact way as chests but with instead of a block concrete block display it uses a slightly scaled down version of the block entity type the container is. This enables outlines on containers like the brewing stand.
### Non-Living Entities
- These are things like minecarts, boat chests, etc
- These just simply set the entity to glowing with `entity.setGlowing(true)`.
- An `UnsetGlowingTask` is ran after 10 seconds to remove the glowing effect and any added data tags
- Sets the `FOUND_TASK_ID` data tag and stores the task ID inside in case the player triggers multiple finditem commands. We can cancel the task and set a new one so the glow doesn't get cut short and is 10 seconds every time the command runs.
### Living Entities
- This simply adds the glowing potion effect for 10 seconds to the living entity. Super simple solution that takes care of itself.
## Other Things of Note
- There is an `EntitiesLoadEvent` that checks if there are any rogue non-living entities that were set to glowing from Vane, that need to be unset. So we shouldn't need to worry about server crashes and that tasks not being run properly.
- When the player right clicks a glowing container, the glow will shut itself off to both mark the container as viewed and also hide the black concrete display entity when chests are open.

Let me know if you'd like me to adjust anything!