### PR TITLE
chore: update dependencies

### DIFF
--- a/.github/workflows/lint-commit.yml
+++ b/.github/workflows/lint-commit.yml
@@ -14,7 +14,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-node@v5.0.0
+      - uses: actions/setup-node@v6.0.0
         with:
           node-version: 22
       - run: |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ paper = "1.21.10-R0.1-SNAPSHOT"
 bstats = "3.1.0"
 
 [libraries]
-annotations = {group = "org.jetbrains", name = "annotations", version = "26.0.2"}
+annotations = {group = "org.jetbrains", name = "annotations", version = "26.0.2-1"}
 reflections = {group = "org.reflections", name = "reflections", version = "0.10.2"}
 commonsLang = {group = "org.apache.commons", name = "commons-lang3", version = "3.19.0"}
 commonsText = {group = "org.apache.commons", name = "commons-text", version = "1.14.0"}
@@ -15,10 +15,10 @@ nightConfig = {group = "com.electronwill.night-config", name = "toml", version =
 bstatsBase = {group = "org.bstats", name = "bstats-base", version.ref = "bstats"}
 bstatsBukkit = {group = "org.bstats", name = "bstats-bukkit", version.ref = "bstats"}
 bstatsVelocity = {group = "org.bstats", name = "bstats-velocity", version.ref = "bstats"}
-protocollib = {group = "net.dmulloy2", name = "ProtocolLib", version = "5.4.0-SNAPSHOT"}
+protocollib = {group = "net.dmulloy2", name = "ProtocolLib", version = "5.4.0"}
 vault = {group = "com.github.MilkBowl", name = "VaultAPI", version = "1.7.1"}
 velocity = {group = "com.velocitypowered", name = "velocity-api", version = "3.4.0-SNAPSHOT"}
-packetEvents = {group = "com.github.retrooper", name = "packetevents-spigot", version = "2.9.5"}
+packetEvents = {group = "com.github.retrooper", name = "packetevents-spigot", version = "2.10.0"}
 
 # maps
 dynmap = {group = "us.dynmap", name = "DynmapCoreAPI", version = "3.7-beta-6"}
@@ -26,6 +26,6 @@ bluemap = {group = "de.bluecolored", name = "bluemap-api", version = "2.7.6"}
 
 [plugins]
 paperweightUserdev = {id = "io.papermc.paperweight.userdev", version = "2.0.0-beta.19"}
-runPaper = {id = "xyz.jpenilla.run-paper", version = "3.0.0"}
+runPaper = {id = "xyz.jpenilla.run-paper", version = "3.0.2"}
 shadow = {id = "com.gradleup.shadow", version = "9.2.2"}
-blossom = {id = "net.kyori.blossom", version = "2.1.0"}
+blossom = {id = "net.kyori.blossom", version = "2.2.0"}


### PR DESCRIPTION
runpaper to v3.0.2
net.dmulloy2:protocollib to v5.4.0
org.jetbrains:annotations to v26.0.2-1
blossom to v2.2.0
com.github.retrooper:packetevents-spigot to v2.10.0
actions/setup-node action to v6